### PR TITLE
[WIP] feat: command for summarizing recent blog articles & podcast episodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lodash.shuffle": "^4.2.0",
     "node-fetch": "^2.6.0",
     "querystring": "^0.2.0",
+    "rss-parser": "^3.11.0",
     "tslib": "^1"
   },
   "devDependencies": {

--- a/src/commands/scheduled/recently-published.ts
+++ b/src/commands/scheduled/recently-published.ts
@@ -59,27 +59,6 @@ export default class ScheduledRecentlyPublished extends Command {
         },
       },
       {
-        type: "divider",
-      },
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text:
-            "Have an idea for a blog post or podcast episode? Swing by the #blogging/#engineering-podcast channels anytime. We also have Writing Office Hours every Monday at 2pm ET.",
-        },
-      },
-      {
-        type: "context",
-        elements: [
-          {
-            type: "mrkdwn",
-            text:
-              "<https://artsy.github.io|Artsy Engineering Blog> | Podcast (<https://podcasts.apple.com/us/podcast/artsy-engineering-radio/id1545870104|iTunes>, <https://podcasts.google.com/feed/aHR0cHM6Ly9hcnRzeS5naXRodWIuaW8vcG9kY2FzdC54bWw|Google>)",
-          },
-        ],
-      },
-      {
         type: "context",
         elements: [
           {

--- a/src/commands/scheduled/recently-published.ts
+++ b/src/commands/scheduled/recently-published.ts
@@ -1,0 +1,47 @@
+import { Command } from "@oclif/command"
+import Parser = require("rss-parser")
+import fetch from "cross-fetch"
+
+export default class ScheduledRecentlyPublished extends Command {
+  static description =
+    "Describe our most recently published articles and podcast episodes"
+
+  async run() {
+    const podcast = await this.getPodcastFeed()
+
+    const response = {
+      blocks: [...podcast],
+    }
+
+    this.log(JSON.stringify(response))
+  }
+
+  async getPodcastFeed() {
+    const PODCAST_FEED_URL = "https://artsy.github.io/podcast.xml"
+
+    const parser = new Parser()
+    const feed = await parser.parseURL(PODCAST_FEED_URL)
+
+    const last = feed.items[feed.items.length - 1]
+    const lastPublishedDate = new Date(last.pubDate!).toLocaleDateString(
+      "en-US",
+      {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      }
+    )
+
+    const blocks = [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `The last episode of *Artsy Engineering Radio* aired on ${lastPublishedDate}:`,
+        },
+      },
+    ]
+
+    return blocks
+  }
+}

--- a/src/commands/scheduled/recently-published.ts
+++ b/src/commands/scheduled/recently-published.ts
@@ -7,41 +7,115 @@ export default class ScheduledRecentlyPublished extends Command {
     "Describe our most recently published articles and podcast episodes"
 
   async run() {
-    const podcast = await this.getPodcastFeed()
+    const podcast = await this.buildPodcastSummary()
+    const callToAction = this.buildCallToAction()
 
     const response = {
-      blocks: [...podcast],
+      blocks: [...podcast, ...callToAction],
     }
 
     this.log(JSON.stringify(response))
   }
 
-  async getPodcastFeed() {
+  async buildPodcastSummary() {
     const PODCAST_FEED_URL = "https://artsy.github.io/podcast.xml"
 
     const parser = new Parser()
     const feed = await parser.parseURL(PODCAST_FEED_URL)
 
-    const last = feed.items[feed.items.length - 1]
-    const lastPublishedDate = new Date(last.pubDate!).toLocaleDateString(
-      "en-US",
-      {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-      }
-    )
+    const lastEpisode = feed.items[feed.items.length - 1]
+    const {
+      title,
+      content,
+      pubDate,
+      itunes: { author },
+    } = lastEpisode
+    const formattedDate = new Date(pubDate!).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    })
 
     const blocks = [
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `The last episode of *Artsy Engineering Radio* aired on ${lastPublishedDate}:`,
+          text: `The last episode of *Artsy Engineering Radio* aired on ${formattedDate}:`,
         },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `${title} | <https://podcasts.apple.com/us/podcast/artsy-engineering-radio/id1545870104|Apple Podcasts> | <https://podcasts.google.com/feed/aHR0cHM6Ly9hcnRzeS5naXRodWIuaW8vcG9kY2FzdC54bWw|Google Podcasts> | <https://open.spotify.com/show/0gJYxpqN6P11dbjNw8VT2a?si=L4TWDrQETwuVO6JR1SOZTQ|Spotify>`,
+        },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `> ${content}`,
+        },
+      },
+      {
+        type: "divider",
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            "Have an idea for a blog post or podcast episode? Swing by the #blogging/#engineering-podcast channels anytime. We also have Writing Office Hours every Monday at 2pm ET.",
+        },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text:
+              "<https://artsy.github.io|Artsy Engineering Blog> | Podcast (<https://podcasts.apple.com/us/podcast/artsy-engineering-radio/id1545870104|iTunes>, <https://podcasts.google.com/feed/aHR0cHM6Ly9hcnRzeS5naXRodWIuaW8vcG9kY2FzdC54bWw|Google>)",
+          },
+        ],
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: `${author} - ${formattedDate}`,
+          },
+        ],
       },
     ]
 
     return blocks
+  }
+
+  buildCallToAction() {
+    return [
+      {
+        type: "divider",
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            "Have an idea for a blog post or podcast episode? Swing by the #blogging/#engineering-podcast channels anytime. We also have Writing Office Hours every Monday at 2pm ET.",
+        },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text:
+              "<https://artsy.github.io|Artsy Engineering> | Podcast (<https://podcasts.apple.com/us/podcast/artsy-engineering-radio/id1545870104|iTunes>, <https://podcasts.google.com/feed/aHR0cHM6Ly9hcnRzeS5naXRodWIuaW8vcG9kY2FzdC54bWw|Google>)",
+          },
+        ],
+      },
+    ]
   }
 }

--- a/src/commands/scheduled/recently-published.ts
+++ b/src/commands/scheduled/recently-published.ts
@@ -1,6 +1,5 @@
 import { Command } from "@oclif/command"
 import Parser = require("rss-parser")
-import fetch from "cross-fetch"
 
 export default class ScheduledRecentlyPublished extends Command {
   static description =

--- a/test/commands/scheduled/recently-published.test.ts
+++ b/test/commands/scheduled/recently-published.test.ts
@@ -10,7 +10,8 @@ describe("scheduled:recently-published", () => {
     .stdout()
     .command(["scheduled:recently-published"])
     .it("shares most recent podcast episode", ctx => {
-      expect(ctx.stdout.trim()).to.include(
+      const response = ctx.stdout.trim()
+      expect(response).to.include(
         JSON.stringify({
           type: "section",
           text: {
@@ -18,6 +19,69 @@ describe("scheduled:recently-published", () => {
             text:
               "The last episode of *Artsy Engineering Radio* aired on Dec 17, 2020:",
           },
+        })
+      )
+      expect(response).to.include(
+        JSON.stringify({
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text:
+              "1: How To Have Good Meetings | <https://podcasts.apple.com/us/podcast/artsy-engineering-radio/id1545870104|Apple Podcasts> | <https://podcasts.google.com/feed/aHR0cHM6Ly9hcnRzeS5naXRodWIuaW8vcG9kY2FzdC54bWw|Google Podcasts> | <https://open.spotify.com/show/0gJYxpqN6P11dbjNw8VT2a?si=L4TWDrQETwuVO6JR1SOZTQ|Spotify>",
+          },
+        })
+      )
+      expect(response).to.include(
+        JSON.stringify({
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text:
+              "> Ash Furrow talks with Steve Hicks about facilitating meaningful and inclusive team meetings, and how meetings are part of building teams, trust, and systems.",
+          },
+        })
+      )
+      expect(response).to.include(
+        JSON.stringify({
+          type: "context",
+          elements: [
+            {
+              type: "mrkdwn",
+              text: "Ash Furrow & Steve Hicks - Dec 17, 2020",
+            },
+          ],
+        })
+      )
+    })
+
+  test
+    .nock("https://artsy.github.io", api =>
+      api.get("/podcast.xml").replyWithFile(200, fixture)
+    )
+    .stdout()
+    .command(["scheduled:recently-published"])
+    .it("lets people know how to contribute", ctx => {
+      const response = ctx.stdout.trim()
+      expect(response).to.include(
+        JSON.stringify({
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text:
+              "Have an idea for a blog post or podcast episode? Swing by the #blogging/#engineering-podcast channels anytime. We also have Writing Office Hours every Monday at 2pm ET.",
+          },
+        })
+      )
+      expect(response).to.include(
+        JSON.stringify({
+          type: "context",
+          elements: [
+            {
+              type: "mrkdwn",
+              text:
+                "<https://artsy.github.io|Artsy Engineering> | Podcast (<https://podcasts.apple.com/us/podcast/artsy-engineering-radio/id1545870104|iTunes>, <https://podcasts.google.com/feed/aHR0cHM6Ly9hcnRzeS5naXRodWIuaW8vcG9kY2FzdC54bWw|Google>)",
+            },
+          ],
         })
       )
     })

--- a/test/commands/scheduled/recently-published.test.ts
+++ b/test/commands/scheduled/recently-published.test.ts
@@ -1,0 +1,24 @@
+import * as path from "path"
+import { expect, test } from "@oclif/test"
+
+describe("scheduled:recently-published", () => {
+  const fixture = path.resolve(__dirname, "../../fixtures/podcast.xml")
+  test
+    .nock("https://artsy.github.io", api =>
+      api.get("/podcast.xml").replyWithFile(200, fixture)
+    )
+    .stdout()
+    .command(["scheduled:recently-published"])
+    .it("shares most recent podcast episode", ctx => {
+      expect(ctx.stdout.trim()).to.include(
+        JSON.stringify({
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text:
+              "The last episode of *Artsy Engineering Radio* aired on Dec 17, 2020:",
+          },
+        })
+      )
+    })
+})

--- a/test/fixtures/podcast.xml
+++ b/test/fixtures/podcast.xml
@@ -1,0 +1,53 @@
+<rss xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:wfw="http://wellformedweb.org/CommentAPI/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xmlns:slash="http://purl.org/rss/1.0/modules/slash/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
+<channel>
+<title>Artsy Engineering Radio</title>
+<atom:link href="https://artsy.github.io/podcast.xml" rel="self" type="application/rss+xml"/>
+<itunes:new-feed-url>https://artsy.github.io/podcast.xml</itunes:new-feed-url>
+<link>https://artsy.github.io</link>
+<description>A podcast exploring questions in software engineering.</description>
+<lastBuildDate>Thu, 11 Feb 2021 22:29:33 +0000</lastBuildDate>
+<sy:updatePeriod>hourly</sy:updatePeriod>
+<sy:updateFrequency>1</sy:updateFrequency>
+<language>en</language>
+<copyright>Artsy, 2020</copyright>
+<itunes:subtitle>A podcast exploring questions in software engineering.</itunes:subtitle>
+<itunes:summary>A podcast exploring questions in software engineering.</itunes:summary>
+<itunes:keywords>engineering, software engineering, software development, open source</itunes:keywords>
+<category>Technology</category>
+<itunes:category text="Technology"/>
+<itunes:author>Artsy Engineering</itunes:author>
+<itunes:owner>
+<itunes:name>Artsy Engineering</itunes:name>
+<itunes:email>OpenSourceGroup@artsy.net</itunes:email>
+</itunes:owner>
+<itunes:block>no</itunes:block>
+<itunes:explicit>no</itunes:explicit>
+<itunes:image href="https://artsy.github.io/images/podcast_logo.png"/>
+<item>
+<title>0: Introducing Artsy Engineering Radio</title>
+<pubDate>Wed, 16 Dec 2020 14:43:48 -0600</pubDate>
+<description>Jon Allured, Matt Dole, and Steve Hicks introduce you to Artsy Engineering Radio and help you understand why you need another podcast in your life.</description>
+<enclosure url="https://artsy-engineering-podcast.s3.amazonaws.com/ArtsyEngineeringRadio-ep0-IntroducingArtsyEngineeringRadio.mp3" length="7500002" type="audio/mpeg"/>
+<link>https://artsy-engineering-podcast.s3.amazonaws.com/ArtsyEngineeringRadio-ep0-IntroducingArtsyEngineeringRadio.mp3</link>
+<guid>https://artsy-engineering-podcast.s3.amazonaws.com/ArtsyEngineeringRadio-ep0-IntroducingArtsyEngineeringRadio.mp3</guid>
+<itunes:author>Jon Allured, Matt Dole, &amp; Steve Hicks</itunes:author>
+<itunes:summary>Jon Allured, Matt Dole, and Steve Hicks introduce you to Artsy Engineering Radio and help you understand why you need another podcast in your life.</itunes:summary>
+<itunes:image href="https://artsy.github.io/images/podcast_logo.png"/>
+<itunes:duration>00:09:02</itunes:duration>
+<itunes:keywords>engineering, software engineering, software development, open source</itunes:keywords>
+</item>
+<item>
+<title>1: How To Have Good Meetings</title>
+<pubDate>Thu, 17 Dec 2020 10:35:52 -0600</pubDate>
+<description>Ash Furrow talks with Steve Hicks about facilitating meaningful and inclusive team meetings, and how meetings are part of building teams, trust, and systems.</description>
+<enclosure url="https://artsy-engineering-podcast.s3.amazonaws.com/ArtsyEngineeringRadio-ep1-GoodMeetingsWithAsh.mp3" length="23607969" type="audio/mpeg"/>
+<link>https://artsy-engineering-podcast.s3.amazonaws.com/ArtsyEngineeringRadio-ep1-GoodMeetingsWithAsh.mp3</link>
+<guid>https://artsy-engineering-podcast.s3.amazonaws.com/ArtsyEngineeringRadio-ep1-GoodMeetingsWithAsh.mp3</guid>
+<itunes:author>Ash Furrow &amp; Steve Hicks</itunes:author>
+<itunes:summary>Ash Furrow talks with Steve Hicks about facilitating meaningful and inclusive team meetings, and how meetings are part of building teams, trust, and systems.</itunes:summary>
+<itunes:image href="https://artsy.github.io/images/podcast_logo.png"/>
+<itunes:duration>00:27:41</itunes:duration>
+<itunes:keywords>engineering, software engineering, software development, open source</itunes:keywords>
+</item>
+</channel>
+</rss>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1813,7 +1813,19 @@ cardinal@^2.1.1:
     ansicolors "~0.3.2"
     redeyed "~2.1.0"
 
-chai@^4, chai@^4.1.2:
+chai@^4:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
+  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.0"
+    type-detect "^4.0.5"
+
+chai@^4.1.2:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.0.tgz#5523a5faf7f819c8a92480d70a8cccbadacfc25f"
   integrity sha512-/BFd2J30EcOwmdOgXvVsmM48l0Br0nmZPlO0uOW4XKh6kpsUumRXBgPV+IlaqFaqr9cYbeoZAM1Npx0i4A+aiA==
@@ -2210,9 +2222,16 @@ deep-eql@^3.0.1:
     type-detect "^4.0.0"
 
 deep-equal@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
+  integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
+  dependencies:
+    is-arguments "^1.0.4"
+    is-date-object "^1.0.1"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object-keys "^1.1.1"
+    regexp.prototype.flags "^1.2.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -2346,6 +2365,11 @@ end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
   dependencies:
     once "^1.4.0"
+
+entities@^2.0.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -3183,6 +3207,13 @@ is-absolute@^1.0.0:
     is-relative "^1.0.0"
     is-windows "^1.0.1"
 
+is-arguments@^1.0.4:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.0.tgz#62353031dfbee07ceb34656a6bde59efecae8dd9"
+  integrity sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==
+  dependencies:
+    call-bind "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -3283,7 +3314,7 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
 
-is-regex@^1.1.1:
+is-regex@^1.0.4, is-regex@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.2.tgz#81c8ebde4db142f2cf1c53fc86d6a45788266251"
   integrity sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==
@@ -3716,10 +3747,15 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5, lodash@~4.17.20:
+lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.19, lodash@^4.17.20, lodash@~4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.5:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -4109,6 +4145,14 @@ object-inspect@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
   integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
+
+object-is@^1.0.1:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
+  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
 
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -4509,9 +4553,9 @@ qqjs@^0.3.10:
     write-json-file "^4.1.1"
 
 qs@^6.5.1:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
-  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+  version "6.9.6"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
+  integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
 
 querystring@^0.2.0:
   version "0.2.0"
@@ -4582,6 +4626,14 @@ regenerator-runtime@^0.13.4:
   version "0.13.7"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+
+regexp.prototype.flags@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
+  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
 
 registry-auth-token@^4.0.0:
   version "4.2.1"
@@ -4739,6 +4791,14 @@ rimraf@^2.6.2, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rss-parser@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/rss-parser/-/rss-parser-3.11.0.tgz#d885ea2ee12758377397648ac20582182379bbf6"
+  integrity sha512-oTLoYW+bNqNwkz8OpGinBU9s3As0sdczQjETIZFgyAdi7AopyhoVFGPIyFMYXXEY8hayKzD5CH+4CtmiPtJ89g==
+  dependencies:
+    entities "^2.0.3"
+    xml2js "^0.4.19"
+
 run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -4775,6 +4835,11 @@ safe-buffer@~5.2.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 scuid@^1.1.0:
   version "1.1.0"
@@ -5571,6 +5636,19 @@ ws@^5.2.0:
   integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
   dependencies:
     async-limiter "~1.0.0"
+
+xml2js@^0.4.19:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 "y18n@^3.2.1 || ^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
Will address #26 eventually.

For now it's emitting slack blocks for summarizing the most recent podcast episode, but I'm planning on adding the blog summary as part of this PR. 

## What the slack blocks look like (so far)

![image](https://user-images.githubusercontent.com/1627089/109034716-8ba14380-768d-11eb-8da1-4b8beb07f830.png)
