### PR TITLE
fix: add @types/xml2js to fix tsc -b

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/mocha": "^5",
     "@types/node": "^14",
     "@types/node-fetch": "^2.5.0",
+    "@types/xml2js": "^0.4.8",
     "chai": "^4",
     "globby": "^10",
     "mocha": "^5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1366,6 +1366,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/xml2js@^0.4.8":
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/@types/xml2js/-/xml2js-0.4.8.tgz#84c120c864a5976d0b5cf2f930a75d850fc2b03a"
+  integrity sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/zen-observable@^0.8.0":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.2.tgz#808c9fa7e4517274ed555fa158f2de4b4f468e71"


### PR DESCRIPTION
Addresses this CI error:

```
node_modules/rss-parser/index.d.ts(1,25): error TS7016: Could not find a declaration file for module 'xml2js'. '/home/circleci/project/node_modules/xml2js/lib/xml2js.js' implicitly has an 'any' type.
  Try `npm install @types/xml2js` if it exists or add a new declaration (.d.ts) file containing `declare module 'xml2js';`
```

https://app.circleci.com/pipelines/github/artsy/cli/223/workflows/33480dcc-99af-4989-9afe-ef19cbf8fea2/jobs/594