### PR TITLE
feat: promote most recent blog posts in scheduled:recently-published command.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  auto: artsy/auto@1.2.0
-  yarn: artsy/yarn@4.0.2
+  auto: artsy/auto@1.3.2
+  yarn: artsy/yarn@5.1.3
 
 workflows:
   default:

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "^3.3"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.0.0"
   },
   "files": [
     "bin",

--- a/src/commands/scheduled/recently-published.ts
+++ b/src/commands/scheduled/recently-published.ts
@@ -46,7 +46,7 @@ export default class ScheduledRecentlyPublished extends Command {
     return blocks
   }
 
-  buildBlogArticleBlocks(post: Parser.Item): Array<any> {
+  buildBlogArticleBlocks(post: Parser.Item) {
     const { link, pubDate, title } = post
     const formattedDate = formatDate(pubDate)
     const blocks = [

--- a/test/commands/scheduled/recently-published.test.ts
+++ b/test/commands/scheduled/recently-published.test.ts
@@ -35,7 +35,7 @@ describe("scheduled:recently-published", () => {
           elements: [
             {
               type: "mrkdwn",
-              text: "Dec 30, 2020",
+              text: "Dec 31, 2020",
             },
           ],
         })

--- a/test/commands/scheduled/recently-published.test.ts
+++ b/test/commands/scheduled/recently-published.test.ts
@@ -2,11 +2,51 @@ import * as path from "path"
 import { expect, test } from "@oclif/test"
 
 describe("scheduled:recently-published", () => {
-  const fixture = path.resolve(__dirname, "../../fixtures/podcast.xml")
+  const blogFixture = path.resolve(__dirname, "../../fixtures/feed.xml")
+  const podcastFixture = path.resolve(__dirname, "../../fixtures/podcast.xml")
+
   test
-    .nock("https://artsy.github.io", api =>
-      api.get("/podcast.xml").replyWithFile(200, fixture)
-    )
+    .nock("https://artsy.github.io", api => {
+      api.get("/feed.xml").replyWithFile(200, blogFixture)
+      api.get("/podcast.xml").replyWithFile(200, podcastFixture)
+    })
+    .stdout()
+    .command(["scheduled:recently-published"])
+    .it("shares most recent blog posts", ctx => {
+      const response = ctx.stdout.trim()
+
+      expect(response).to.include(
+        " days ago* we published our most recent article on the *Artsy Engineering Blog*. Here are our most recent posts -- read and share them!"
+      )
+
+      expect(response).to.include(
+        JSON.stringify({
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text:
+              "<https://artsy.github.io/blog/2020/12/31/echo-supporting-old-app-versions/|Echoes From the Past: Supporting Old App Versions>",
+          },
+        })
+      )
+      expect(response).to.include(
+        JSON.stringify({
+          type: "context",
+          elements: [
+            {
+              type: "mrkdwn",
+              text: "Dec 30, 2020",
+            },
+          ],
+        })
+      )
+    })
+
+  test
+    .nock("https://artsy.github.io", api => {
+      api.get("/feed.xml").replyWithFile(200, blogFixture)
+      api.get("/podcast.xml").replyWithFile(200, podcastFixture)
+    })
     .stdout()
     .command(["scheduled:recently-published"])
     .it("shares most recent podcast episode", ctx => {
@@ -55,9 +95,10 @@ describe("scheduled:recently-published", () => {
     })
 
   test
-    .nock("https://artsy.github.io", api =>
-      api.get("/podcast.xml").replyWithFile(200, fixture)
-    )
+    .nock("https://artsy.github.io", api => {
+      api.get("/feed.xml").replyWithFile(200, blogFixture)
+      api.get("/podcast.xml").replyWithFile(200, podcastFixture)
+    })
     .stdout()
     .command(["scheduled:recently-published"])
     .it("lets people know how to contribute", ctx => {

--- a/test/fixtures/feed.xml
+++ b/test/fixtures/feed.xml
@@ -1,0 +1,44 @@
+<!-- note: the <description> fields in this fixture are altered because nock can't parse the html inside of our actual feed's descriptions. -->
+<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+<channel>
+<title>Artsy Engineering</title>
+<description/>
+<link>https://artsy.github.io/</link>
+<atom:link href="https://artsy.github.io/feed.xml" rel="self" type="application/rss+xml"/>
+<pubDate>Thu, 04 Mar 2021 23:07:28 +0000</pubDate>
+<lastBuildDate>Thu, 04 Mar 2021 23:07:28 +0000</lastBuildDate>
+<generator>Jekyll v2.5.3</generator>
+<item>
+<title>Why Asking for Help Strengthens Engineering Teams</title>
+<description>I know that for many developers, especially those early in their careers, asking for help can be intimidating.</description>
+<pubDate>Thu, 11 Feb 2021 00:00:00 +0000</pubDate>
+<link>https://artsy.github.io/blog/2021/02/11/asking-for-help/</link>
+<guid isPermaLink="true">https://artsy.github.io/blog/2021/02/11/asking-for-help/</guid>
+<category>community</category>
+<category>culture</category>
+<category>learning</category>
+<category>teaching</category>
+<category>team</category>
+</item>
+<item>
+<title>Introducing Artsy Engineering Radio</title>
+<description>Available now on Apple Podcasts</description>
+<pubDate>Wed, 06 Jan 2021 00:00:00 +0000</pubDate>
+<link>https://artsy.github.io/blog/2021/01/06/introducing-artsy-engineering-radio/</link>
+<guid isPermaLink="true">https://artsy.github.io/blog/2021/01/06/introducing-artsy-engineering-radio/</guid>
+<category>community</category>
+<category>learning</category>
+<category>podcast</category>
+</item>
+<item>
+<title>Echoes From the Past: Supporting Old App Versions</title>
+<description>In a recent blog post, I discussed a fundamental difference between web and iOS deployments.</description>
+<pubDate>Thu, 31 Dec 2020 00:00:00 +0000</pubDate>
+<link>https://artsy.github.io/blog/2020/12/31/echo-supporting-old-app-versions/</link>
+<guid isPermaLink="true">https://artsy.github.io/blog/2020/12/31/echo-supporting-old-app-versions/</guid>
+<category>ios</category>
+<category>mobile</category>
+<category>teams</category>
+</item>
+</channel>
+</rss>

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,5 +2,5 @@
 --watch-extensions ts
 --recursive
 --reporter spec
---timeout 5000
+--timeout 10000
 --file test/setup-mocha.ts

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "strict": true,
-    "target": "es2017"
+    "target": "es2019"
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Adds some blocks to promote our most recent blog posts. Addresses #26.

Looks like this:

![image](https://user-images.githubusercontent.com/1627089/110178245-c7de4d80-7dcb-11eb-9b48-42da5db4d41e.png)

I opted to do a "days since" counter for blog posts because I secretly hope it will let people know when it's been a looonnngggg time since we published.