### PR TITLE
chore: configure node orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   auto: artsy/auto@1.3.2
+  node: artsy/node@1.0.0
   yarn: artsy/yarn@5.1.3
 
 workflows:


### PR DESCRIPTION
Hoping that this configures the artsy/yarn orb to use the NodeJS v12 execution environment from the updated artsy/node orb.