### PR TITLE
chore: use auto/publish-canary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - yarn/update-cache
       - yarn/lint
       - yarn/test
-      - auto/publish:
+      - auto/publish-canary:
           context: npm-deploy
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   auto: artsy/auto@1.3.2
-  node: artsy/node@1.0.0
   yarn: artsy/yarn@5.1.3
 
 workflows:


### PR DESCRIPTION
Looks like we have another auto/publish-canary job which targets NodeJS v12.