### PR TITLE
feat: add audit:repositories command

### DIFF
--- a/src/__generated__/graphql.ts
+++ b/src/__generated__/graphql.ts
@@ -12775,6 +12775,8 @@ export type Release = Node & UniformResourceLocatable & {
   publishedAt?: Maybe<Scalars['DateTime']>;
   /** List of releases assets which are dependent on this release. */
   releaseAssets: ReleaseAssetConnection;
+  /** The repository that the release belongs to. */
+  repository: Repository;
   /** The HTTP path for this issue */
   resourcePath: Scalars['URI'];
   /** A description of the release, rendered to HTML without any links in it. */
@@ -25892,6 +25894,7 @@ export type ReleaseResolvers<ContextType = any, ParentType extends ResolversPare
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   publishedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   releaseAssets?: Resolver<ResolversTypes['ReleaseAssetConnection'], ParentType, ContextType, RequireFields<ReleaseReleaseAssetsArgs, never>>;
+  repository?: Resolver<ResolversTypes['Repository'], ParentType, ContextType>;
   resourcePath?: Resolver<ResolversTypes['URI'], ParentType, ContextType>;
   shortDescriptionHTML?: Resolver<Maybe<ResolversTypes['HTML']>, ParentType, ContextType, RequireFields<ReleaseShortDescriptionHtmlArgs, 'limit'>>;
   tag?: Resolver<Maybe<ResolversTypes['Ref']>, ParentType, ContextType>;
@@ -29156,6 +29159,22 @@ export const OpenRequestsForComments = gql`
   }
 }
     `;
+export const ArtsyRepositories = gql`
+    query ArtsyRepositories($query: String!) {
+  search(query: $query, type: REPOSITORY, first: 100) {
+    __typename
+    nodes {
+      __typename
+      ... on Repository {
+        name
+        defaultBranchRef {
+          name
+        }
+      }
+    }
+  }
+}
+    `;
 export type OpenRequestsForCommentsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -29253,5 +29272,25 @@ export type OpenRequestsForCommentsQuery = (
         ) | { __typename: 'LabeledEvent' } | { __typename: 'LockedEvent' } | { __typename: 'MarkedAsDuplicateEvent' } | { __typename: 'MentionedEvent' } | { __typename: 'MergedEvent' } | { __typename: 'MilestonedEvent' } | { __typename: 'MovedColumnsInProjectEvent' } | { __typename: 'PinnedEvent' } | { __typename: 'PullRequestCommit' } | { __typename: 'PullRequestCommitCommentThread' } | { __typename: 'PullRequestReview' } | { __typename: 'PullRequestReviewThread' } | { __typename: 'PullRequestRevisionMarker' } | { __typename: 'ReadyForReviewEvent' } | { __typename: 'ReferencedEvent' } | { __typename: 'RemovedFromProjectEvent' } | { __typename: 'RenamedTitleEvent' } | { __typename: 'ReopenedEvent' } | { __typename: 'ReviewDismissedEvent' } | { __typename: 'ReviewRequestRemovedEvent' } | { __typename: 'ReviewRequestedEvent' } | { __typename: 'SubscribedEvent' } | { __typename: 'TransferredEvent' } | { __typename: 'UnassignedEvent' } | { __typename: 'UnlabeledEvent' } | { __typename: 'UnlockedEvent' } | { __typename: 'UnmarkedAsDuplicateEvent' } | { __typename: 'UnpinnedEvent' } | { __typename: 'UnsubscribedEvent' } | { __typename: 'UserBlockedEvent' }>>> }
       ) }
     ) | { __typename: 'Repository' } | { __typename: 'User' }>>> }
+  ) }
+);
+
+export type ArtsyRepositoriesQueryVariables = Exact<{
+  query: Scalars['String'];
+}>;
+
+
+export type ArtsyRepositoriesQuery = (
+  { __typename?: 'Query' }
+  & { search: (
+    { __typename: 'SearchResultItemConnection' }
+    & { nodes?: Maybe<Array<Maybe<{ __typename: 'App' } | { __typename: 'Issue' } | { __typename: 'MarketplaceListing' } | { __typename: 'Organization' } | { __typename: 'PullRequest' } | (
+      { __typename: 'Repository' }
+      & Pick<Repository, 'name'>
+      & { defaultBranchRef?: Maybe<(
+        { __typename?: 'Ref' }
+        & Pick<Ref, 'name'>
+      )> }
+    ) | { __typename: 'User' }>>> }
   ) }
 );

--- a/src/commands/audit/repositories.ts
+++ b/src/commands/audit/repositories.ts
@@ -1,0 +1,63 @@
+import { flags } from "@oclif/command"
+import { cli } from "cli-ux"
+import {
+  ArtsyRepositories,
+  ArtsyRepositoriesQuery,
+} from "../../__generated__/graphql"
+import Command from "../../base"
+import { githubClient } from "../../utils/github"
+
+export default class Repositories extends Command {
+  static description = "Audit GitHub repositories."
+
+  static flags = {
+    ...Command.flags,
+    ...cli.table.flags(),
+    "default-branch": flags.string({
+      description: "List only repos with a specific default branch",
+    }),
+    pushed: flags.string({
+      default: ">2021-01-01",
+      description: "Pushed to",
+    }),
+  }
+
+  async run() {
+    const { flags } = this.parse(Repositories)
+
+    const {
+      data: { search },
+    } = await githubClient().query<ArtsyRepositoriesQuery>({
+      query: ArtsyRepositories,
+      variables: { query: `org:artsy pushed:${flags.pushed}` },
+    })
+
+    let repositories = []
+    if (flags["default-branch"]) {
+      search.nodes?.forEach(repository => {
+        if (repository && repository.__typename === "Repository") {
+          if (repository.defaultBranchRef?.name === flags["default-branch"]) {
+            repositories.push(repository)
+          }
+        }
+      })
+    } else {
+      repositories = search.nodes as any[]
+    }
+
+    cli.table(
+      repositories,
+      {
+        name: {},
+        defaultBranch: {
+          header: "Default Branch",
+          get: row => row.defaultBranchRef && row.defaultBranchRef.name,
+        },
+      },
+      {
+        printLine: this.log,
+        ...flags,
+      }
+    )
+  }
+}

--- a/src/queries/repositories.graphql
+++ b/src/queries/repositories.graphql
@@ -1,0 +1,14 @@
+query ArtsyRepositories($query: String!) {
+  search(query: $query, type: REPOSITORY, first: 100) {
+    __typename
+    nodes {
+      __typename
+      ... on Repository {
+        name
+        defaultBranchRef {
+          name
+        }
+      }
+    }
+  }
+}

--- a/test/commands/audit/repositories.test.ts
+++ b/test/commands/audit/repositories.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "@oclif/test"
+import { RepositoriesFixture } from "../../fixtures/repositories"
+
+describe("scheduled:rfcs", () => {
+  beforeEach(() => {
+    process.env.GITHUB_TOKEN = "test"
+  })
+
+  afterEach(() => {
+    delete process.env.GITHUB_TOKEN
+  })
+
+  test
+    .nock("https://api.github.com", api =>
+      api.post("/graphql").reply(200, RepositoriesFixture)
+    )
+    .stdout()
+    .command(["audit:repositories", "--csv"])
+    .it("lists repositories in the artsy github org", ctx => {
+      expect(ctx.stdout.trim()).to.eq("Name,Default Branch\neigen,master")
+    })
+})

--- a/test/fixtures/repositories.ts
+++ b/test/fixtures/repositories.ts
@@ -1,0 +1,17 @@
+export const RepositoriesFixture = {
+  data: {
+    search: {
+      __typename: "SearchResultItemConnection",
+      nodes: [
+        {
+          __typename: "Repository",
+          name: "eigen",
+          defaultBranchRef: {
+            __typename: "Ref",
+            name: "master",
+          },
+        },
+      ],
+    },
+  },
+}


### PR DESCRIPTION
Fetch and display information for repositories within the Artsy GitHub organization.

Initially to be used to aid in our switch from a default branch of `master` to `main`.

Usage:

```
$ artsy audit:repositories
$ artsy audit:repositories --csv
$ artsy audit:repositories --csv --default-branch=main
$ artsy audit:repositories --csv --default-branch=main --pushed=">2021-05-01"
```

@kajatiger Thought this might be a useful command to help with https://github.com/artsy/README/pull/387!