### PR TITLE
chore: update writing office hours time

### DIFF
--- a/src/commands/scheduled/recently-published.ts
+++ b/src/commands/scheduled/recently-published.ts
@@ -134,7 +134,7 @@ export default class ScheduledRecentlyPublished extends Command {
         text: {
           type: "mrkdwn",
           text:
-            "Have an idea for a blog post or podcast episode? Swing by the #blogging/#engineering-podcast channels anytime. We also have Writing Office Hours every Monday at 2pm ET.",
+            "Have an idea for a blog post or podcast episode? Swing by the #blogging/#engineering-podcast channels anytime. We also have Writing Office Hours every Tuesday at 11am ET.",
         },
       },
       {

--- a/test/commands/scheduled/recently-published.test.ts
+++ b/test/commands/scheduled/recently-published.test.ts
@@ -109,7 +109,7 @@ describe("scheduled:recently-published", () => {
           text: {
             type: "mrkdwn",
             text:
-              "Have an idea for a blog post or podcast episode? Swing by the #blogging/#engineering-podcast channels anytime. We also have Writing Office Hours every Monday at 2pm ET.",
+              "Have an idea for a blog post or podcast episode? Swing by the #blogging/#engineering-podcast channels anytime. We also have Writing Office Hours every Tuesday at 11am ET.",
           },
         })
       )


### PR DESCRIPTION
I moved writing office hours a few weeks ago to be more friendly to engineers in Europe. This updates our slack reminder to tell people the correct info!