### PR TITLE
chore(auto): pin to more recent auto version

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,4 +1,3 @@
 {
-  "extends": "@artsy",
-  "baseBranch": "main"
+  "extends": "@artsy"
 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ workflows:
       - yarn/test
       - auto/publish:
           context: npm-deploy
+          version: v10.29.3
           filters:
             branches:
               only: main


### PR DESCRIPTION
The default auto version is specified in our Circle CI orb [here][0]. This is used to determine which version of the tool we download into the Circle CI container.

I'm hoping that we can override the orb's environment variable by specifying a value here in the project's config.

[0]: https://github.com/artsy/orbs/blob/e480ac7adbbe923d58e5726d6c34b0ce3eb63815/src/auto/auto.yml#L17