### PR TITLE
feat: improve recent podcast summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "querystring": "^0.2.0",
     "rss-parser": "^3.11.0",
     "tslib": "^2",
+    "turndown": "^7.1.1",
     "uri-scheme": "^1.0.76"
   },
   "devDependencies": {

--- a/src/commands/scheduled/recently-published.ts
+++ b/src/commands/scheduled/recently-published.ts
@@ -90,6 +90,7 @@ export default class ScheduledRecentlyPublished extends Command {
     } = lastEpisode
     const formattedDate = formatDate(pubDate)
     const webURL = formatWebURL(enclosure?.url)
+    const formattedContent = formatContent(content)
 
     const blocks = [
       {
@@ -110,7 +111,7 @@ export default class ScheduledRecentlyPublished extends Command {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `> ${content}`,
+          text: `> ${formattedContent}`,
         },
       },
       {
@@ -185,4 +186,15 @@ function formatWebURL(urlString: string | undefined) {
   }
 
   return urlString.replace(".mp3", "")
+}
+
+function formatContent(content: string | undefined) {
+  if (content === undefined) {
+    return ""
+  }
+
+  // BuzzSprout gives us html for this field; slack needs markdown or plaintext.
+  //   For now, scrubbing the paragraph tags will fix most episodes.
+  // TODO: proper html-to-markdown conversion
+  return content.replace("<p>", "").replace("</p>", "")
 }

--- a/src/commands/scheduled/recently-published.ts
+++ b/src/commands/scheduled/recently-published.ts
@@ -173,5 +173,6 @@ function formatDate(dateString: string | undefined) {
     year: "numeric",
     month: "short",
     day: "numeric",
+    timeZone: "UTC",
   })
 }

--- a/src/commands/scheduled/recently-published.ts
+++ b/src/commands/scheduled/recently-published.ts
@@ -144,7 +144,7 @@ export default class ScheduledRecentlyPublished extends Command {
           {
             type: "mrkdwn",
             text:
-              "<https://artsy.github.io|Artsy Engineering> | Podcast (<https://podcasts.apple.com/us/podcast/artsy-engineering-radio/id1545870104|iTunes>, <https://podcasts.google.com/feed/aHR0cHM6Ly9hcnRzeS5naXRodWIuaW8vcG9kY2FzdC54bWw|Google>)",
+              "<https://artsy.github.io|Artsy Engineering> | <https://artsyengineeringradio.buzzsprout.com|Artsy Engineering Radio>",
           },
         ],
       },

--- a/src/commands/scheduled/recently-published.ts
+++ b/src/commands/scheduled/recently-published.ts
@@ -86,8 +86,10 @@ export default class ScheduledRecentlyPublished extends Command {
       content,
       pubDate,
       itunes: { author },
+      enclosure,
     } = lastEpisode
     const formattedDate = formatDate(pubDate)
+    const webURL = formatWebURL(enclosure?.url)
 
     const blocks = [
       {
@@ -101,7 +103,7 @@ export default class ScheduledRecentlyPublished extends Command {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `${title} | <https://podcasts.apple.com/us/podcast/artsy-engineering-radio/id1545870104|Apple Podcasts> | <https://podcasts.google.com/feed/aHR0cHM6Ly9hcnRzeS5naXRodWIuaW8vcG9kY2FzdC54bWw|Google Podcasts> | <https://open.spotify.com/show/0gJYxpqN6P11dbjNw8VT2a?si=L4TWDrQETwuVO6JR1SOZTQ|Spotify>`,
+          text: `<${webURL}|${title}>`,
         },
       },
       {
@@ -175,4 +177,12 @@ function formatDate(dateString: string | undefined) {
     day: "numeric",
     timeZone: "UTC",
   })
+}
+
+function formatWebURL(urlString: string | undefined) {
+  if (urlString === undefined) {
+    return ""
+  }
+
+  return urlString.replace(".mp3", "")
 }

--- a/src/commands/scheduled/recently-published.ts
+++ b/src/commands/scheduled/recently-published.ts
@@ -195,7 +195,9 @@ function formatContent(content: string | undefined) {
   }
 
   // BuzzSprout gives us html for this field; slack needs markdown or plaintext.
-  var turndownService = new TurndownService()
-  var markdown = turndownService.turndown(`<blockquote>${content}</blockquote>`)
+  const turndownService = new TurndownService()
+  const markdown = turndownService.turndown(
+    `<blockquote>${content}</blockquote>`
+  )
   return markdown
 }

--- a/src/commands/scheduled/recently-published.ts
+++ b/src/commands/scheduled/recently-published.ts
@@ -1,5 +1,6 @@
 import { Command } from "@oclif/command"
 import Parser = require("rss-parser")
+import TurndownService = require("turndown")
 
 export default class ScheduledRecentlyPublished extends Command {
   static description =
@@ -111,7 +112,7 @@ export default class ScheduledRecentlyPublished extends Command {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `> ${formattedContent}`,
+          text: `${formattedContent}`,
         },
       },
       {
@@ -194,7 +195,7 @@ function formatContent(content: string | undefined) {
   }
 
   // BuzzSprout gives us html for this field; slack needs markdown or plaintext.
-  //   For now, scrubbing the paragraph tags will fix most episodes.
-  // TODO: proper html-to-markdown conversion
-  return content.replace("<p>", "").replace("</p>", "")
+  var turndownService = new TurndownService()
+  var markdown = turndownService.turndown(`<blockquote>${content}</blockquote>`)
+  return markdown
 }

--- a/test/commands/scheduled/recently-published.test.ts
+++ b/test/commands/scheduled/recently-published.test.ts
@@ -71,7 +71,7 @@ describe("scheduled:recently-published", () => {
           text: {
             type: "mrkdwn",
             text:
-              "19: Humanizing The Workplace | <https://podcasts.apple.com/us/podcast/artsy-engineering-radio/id1545870104|Apple Podcasts> | <https://podcasts.google.com/feed/aHR0cHM6Ly9hcnRzeS5naXRodWIuaW8vcG9kY2FzdC54bWw|Google Podcasts> | <https://open.spotify.com/show/0gJYxpqN6P11dbjNw8VT2a?si=L4TWDrQETwuVO6JR1SOZTQ|Spotify>",
+              "<https://www.buzzsprout.com/1781859/8600736-19-humanizing-the-workplace|19: Humanizing The Workplace>",
           },
         })
       )

--- a/test/commands/scheduled/recently-published.test.ts
+++ b/test/commands/scheduled/recently-published.test.ts
@@ -127,7 +127,7 @@ describe("scheduled:recently-published", () => {
             {
               type: "mrkdwn",
               text:
-                "<https://artsy.github.io|Artsy Engineering> | Podcast (<https://podcasts.apple.com/us/podcast/artsy-engineering-radio/id1545870104|iTunes>, <https://podcasts.google.com/feed/aHR0cHM6Ly9hcnRzeS5naXRodWIuaW8vcG9kY2FzdC54bWw|Google>)",
+                "<https://artsy.github.io|Artsy Engineering> | <https://artsyengineeringradio.buzzsprout.com|Artsy Engineering Radio>",
             },
           ],
         })

--- a/test/commands/scheduled/recently-published.test.ts
+++ b/test/commands/scheduled/recently-published.test.ts
@@ -81,7 +81,7 @@ describe("scheduled:recently-published", () => {
           text: {
             type: "mrkdwn",
             text:
-              "> <p>Steve Hicks and Justin Bennett talk about empathy in workplace culture, how to build trust and safety, and the importance of providing space for people.</p>",
+              "> Steve Hicks and Justin Bennett talk about empathy in workplace culture, how to build trust and safety, and the importance of providing space for people.",
           },
         })
       )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2443,6 +2443,11 @@ doctrine@0.7.2:
     esutils "^1.1.6"
     isarray "0.0.1"
 
+domino@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/domino/-/domino-2.1.6.tgz#fe4ace4310526e5e7b9d12c7de01b7f485a57ffe"
+  integrity sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==
+
 dot-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
@@ -5366,6 +5371,13 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
+
+turndown@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.1.1.tgz#96992f2d9b40a1a03d3ea61ad31b5a5c751ef77f"
+  integrity sha512-BEkXaWH7Wh7e9bd2QumhfAXk5g34+6QUmmWx+0q6ThaVOLuLUqsnkq35HQ5SBHSaxjSfSM7US5o4lhJNH7B9MA==
+  dependencies:
+    domino "^2.1.6"
 
 type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
Cleans up a few things for the `scheduled:recently-published` task, for the weekly update that gets posted to slack. 

1. Fixes a test that was failing locally due to time zones & blog rss dates not having times
2. Replaces apple/google podcast URLs with buzzsprout
3. Links episodes directly to the buzzsprout page
4. Cleans up the episode description, which I noticed after #232 was not actually markdown (buzzsprout gives us raw HTML)

## What the updated blocks look like

![image](https://user-images.githubusercontent.com/1627089/125356713-327c3880-e32c-11eb-846e-400a3f13f8b9.png)

(The gray "Artsy Engineering" next to "Jul 8, 2021" is the author of the episode...I think we've not been filling it in on buzzsprout when we upload episodes, and it defaults to our account name.)
