### PR TITLE
feat: add POC for commands which execute python scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:17
+
+WORKDIR /usr/src/app
+
+RUN apt-get update -y && \
+    apt-get install -y python
+
+COPY package.json ./
+
+RUN npm install
+
+COPY . .
+
+ENTRYPOINT ["/usr/src/app/bin/run"]

--- a/bin/docker-run
+++ b/bin/docker-run
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+docker run \
+  --interactive \
+  --tty \
+  --volume="$(pwd):/usr/src/app" \
+  --env-file=".env" \
+  artsy/cli "$@"

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+print("Hello World!")

--- a/src/commands/python/test.ts
+++ b/src/commands/python/test.ts
@@ -1,0 +1,22 @@
+const { execFile } = require("child_process")
+const path = require("path")
+
+import Command from "../../base"
+
+export default class Test extends Command {
+  async run() {
+    const filePath = path.join(__dirname, "../../../scripts/test.py")
+
+    execFile(filePath, async (error: Error, stdout: string) => {
+      let result
+
+      if (error) {
+        result = error.toString()
+      } else {
+        result = stdout
+      }
+
+      this.log(result.trim())
+    })
+  }
+}


### PR DESCRIPTION
- Dockerfile to build an image including Node, Python, and project dependencies
- bin/docker-run script to execute CLI commands within a Docker container
- python:test command as a POC

To try it out, you can run the following commands:

```
$ docker build -t artsy/cli .
$ bin/docker-run python:test
```

Since I also have Python installed locally, I'm also able to run the task using the local CLI runner:

```
$ bin/run python:test
```