### PR TITLE
feat: Use more standard config approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ Artsy CLI is published on npm, so installing is really easy:
 $ npm install --global @artsy/cli
 ```
 
+## Setup
+
+In order to access shared config, run these commands:
+
+```
+$ mkdir -p ~/.config/artsy
+$ aws s3 cp s3://artsy-citadel/dev/artsy-cli-config.json ~/.config/artsy/config.json
+```
+
 ## Docs
 
 - [Artsy Open Docs](docs/open.md)

--- a/src/commands/identify.ts
+++ b/src/commands/identify.ts
@@ -23,7 +23,7 @@ export default class Identify extends Command {
     const { args } = this.parse(Identify)
     const { id } = args
 
-    if (!Config.readToken())
+    if (!Config.gravityToken())
       this.error("You are not logged in. Run `artsy login`.")
 
     const gravityPromises = Identify.collectionsToCheck.map(collection => {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,5 +1,4 @@
 import cli from "cli-ux"
-import fetch from "node-fetch"
 import { parse } from "querystring"
 import Command from "../base"
 import { Config } from "../config"

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -31,7 +31,7 @@ export default class Login extends Command {
         body: params,
       })
 
-      if (!response.ok) this.error(`${response.status} ${response.statusText}`)
+      if (!response.ok) throw `${response.status} ${response.statusText}`
 
       const data = await response.json()
 
@@ -51,10 +51,13 @@ export default class Login extends Command {
         server.close()
 
         if (query.code) {
-          const data = await getAccessToken(query.code.toString())
-          Config.writeToken(data.access_token)
-
-          cli.action.stop("logged in!")
+          try {
+            const data = await getAccessToken(query.code.toString())
+            Config.writeToken(data.access_token)
+            cli.action.stop("logged in!")
+          } catch (error) {
+            this.error(error)
+          }
         }
       })
       .listen(Gravity.REDIRECT_PORT)

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -41,8 +41,8 @@ export default class Login extends Command {
         }
       })
       .listen(Gravity.REDIRECT_PORT)
-    await cli.open(
-      `${Gravity.urls.auth}?client_id=${process.env.CLIENT_ID}&redirect_uri=http://127.0.0.1:${Gravity.REDIRECT_PORT}&response_type=code`
-    )
+
+    const authUrl = `${Gravity.urls.auth}?client_id=${process.env.CLIENT_ID}&redirect_uri=http://127.0.0.1:${Gravity.REDIRECT_PORT}&response_type=code`
+    await cli.open(authUrl)
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -18,26 +18,6 @@ export default class Login extends Command {
 
     cli.action.start("Waiting for response")
 
-    const getAccessToken = async (code: string) => {
-      const params = new URLSearchParams()
-      params.append("code", code.toString())
-      params.append("client_id", process.env.CLIENT_ID as string)
-      params.append("client_secret", process.env.CLIENT_SECRET as string)
-      params.append("grant_type", "authorization_code")
-      params.append("scope", "offline_access")
-
-      const response = await fetch(Gravity.urls.access_token, {
-        method: "POST",
-        body: params,
-      })
-
-      if (!response.ok) throw `${response.status} ${response.statusText}`
-
-      const data = await response.json()
-
-      return data
-    }
-
     const server = require("http")
       .createServer(async (req: any, res: any) => {
         const url = new URL(req.url, Gravity.urls.callback)
@@ -52,7 +32,7 @@ export default class Login extends Command {
 
         if (query.code) {
           try {
-            const data = await getAccessToken(query.code.toString())
+            const data = await Gravity.getAccessToken(query.code.toString())
             Config.writeToken(data.access_token)
             cli.action.stop("logged in!")
           } catch (error) {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -42,7 +42,6 @@ export default class Login extends Command {
       })
       .listen(Gravity.REDIRECT_PORT)
 
-    const authUrl = `${Gravity.urls.auth}?client_id=${process.env.CLIENT_ID}&redirect_uri=http://127.0.0.1:${Gravity.REDIRECT_PORT}&response_type=code`
-    await cli.open(authUrl)
+    await cli.open(Gravity.authUrl())
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -33,7 +33,7 @@ export default class Login extends Command {
         if (query.code) {
           try {
             const data = await Gravity.getAccessToken(query.code.toString())
-            Config.writeToken(data.access_token)
+            Config.updateConfig({ accessToken: data.access_token })
             cli.action.stop("logged in!")
           } catch (error) {
             this.error(error)

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -11,7 +11,7 @@ export default class Logout extends Command {
   }
 
   async run() {
-    const token = Config.readToken()
+    const token = Config.gravityToken()
 
     if (!token) {
       this.log("Already logged out!")

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -27,7 +27,7 @@ export default class Logout extends Command {
 
     if (!response.ok) this.error(`${response.status} ${response.statusText}`)
 
-    Config.writeToken("")
+    Config.updateConfig({ accessToken: "" })
     this.log("Logged out!")
   }
 }

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -15,11 +15,11 @@ export default class WhoAmI extends Command {
   async run() {
     const { flags } = this.parse(WhoAmI)
 
-    const token = Config.readToken()
+    const token = Config.gravityToken()
     if (!token) this.error("You are not logged in. Run `artsy login`.")
 
     const userResponse = await fetch(Gravity.urls.current_user, {
-      headers: { "X-Access-Token": Config.readToken() },
+      headers: { "X-Access-Token": Config.gravityToken() },
     })
 
     const json = await userResponse.json()

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,15 @@ export const Config = {
   path: (): string => {
     return `${os.homedir()}/.config/artsy/config.json`
   },
+  readConfig: (): any => {
+    try {
+      const path = Config.path()
+      const data = fs.readFileSync(path)
+      return JSON.parse(data)
+    } catch {
+      return {}
+    }
+  },
   readOpenConfig: (): any => {
     try {
       return JSON.parse(
@@ -15,18 +24,15 @@ export const Config = {
     }
   },
   gravityId: (): string => {
-    const data = fs.readFileSync(Config.path())
-    const json = JSON.parse(data)
+    const json = Config.readConfig()
     return json.clients.gravity.clientId
   },
   gravitySecret: (): string => {
-    const data = fs.readFileSync(Config.path())
-    const json = JSON.parse(data)
+    const json = Config.readConfig()
     return json.clients.gravity.clientSecret
   },
   gravityToken: (): string => {
-    const data = fs.readFileSync(Config.path())
-    const json = JSON.parse(data)
+    const json = Config.readConfig()
     return json.accessToken
   },
   writeToken: (token: string): void => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,9 +35,12 @@ export const Config = {
     const json = Config.readConfig()
     return json.accessToken
   },
-  writeToken: (token: string): void => {
-    const options = { accessToken: token }
+  writeConfig: (options: object): void => {
     const data = JSON.stringify(options, null, 2)
     fs.writeFileSync(Config.path(), data)
+  },
+  writeToken: (token: string): void => {
+    const options = { accessToken: token }
+    Config.writeConfig(options)
   },
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ const os = require("os")
 
 export const Config = {
   path: (): string => {
-    return `${os.homedir()}/.config/artsy`
+    return `${os.homedir()}/.config/artsy/config.json`
   },
   readOpenConfig: (): any => {
     try {
@@ -15,9 +15,13 @@ export const Config = {
     }
   },
   gravityToken: (): string => {
-    return fs.readFileSync(Config.path(), { encoding: "utf-8" })
+    const data = fs.readFileSync(Config.path())
+    const json = JSON.parse(data)
+    return json.accessToken
   },
   writeToken: (token: string): void => {
-    fs.writeFileSync(Config.path(), token)
+    const options = { accessToken: token }
+    const data = JSON.stringify(options, null, 2)
+    fs.writeFileSync(Config.path(), data)
   },
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,12 +35,16 @@ export const Config = {
     const json = Config.readConfig()
     return json.accessToken
   },
+  updateConfig: (newOptions: object): void => {
+    const existingOptions = Config.readConfig()
+    const options = {
+      ...existingOptions,
+      ...newOptions,
+    }
+    Config.writeConfig(options)
+  },
   writeConfig: (options: object): void => {
     const data = JSON.stringify(options, null, 2)
     fs.writeFileSync(Config.path(), data)
-  },
-  writeToken: (token: string): void => {
-    const options = { accessToken: token }
-    Config.writeConfig(options)
   },
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,16 @@ export const Config = {
       return {}
     }
   },
+  gravityId: (): string => {
+    const data = fs.readFileSync(Config.path())
+    const json = JSON.parse(data)
+    return json.clients.gravity.clientId
+  },
+  gravitySecret: (): string => {
+    const data = fs.readFileSync(Config.path())
+    const json = JSON.parse(data)
+    return json.clients.gravity.clientSecret
+  },
   gravityToken: (): string => {
     const data = fs.readFileSync(Config.path())
     const json = JSON.parse(data)

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ export const Config = {
       return {}
     }
   },
-  readToken: (): string => {
+  gravityToken: (): string => {
     return fs.readFileSync(Config.path(), { encoding: "utf-8" })
   },
   writeToken: (token: string): void => {

--- a/src/utils/gravity.ts
+++ b/src/utils/gravity.ts
@@ -23,7 +23,7 @@ class Gravity {
     const params = new URLSearchParams()
 
     params.append("client_id", Config.gravityId())
-    params.append("redirect_uri", `http://127.0.0.1:${Gravity.REDIRECT_PORT}`)
+    params.append("redirect_uri", Gravity.urls.callback)
     params.append("response_type", "code")
 
     const url = `${Gravity.urls.auth}?${params.toString()}`
@@ -43,7 +43,8 @@ class Gravity {
       body: params,
     })
 
-    if (!response.ok) throw `${response.status} ${response.statusText}`
+    if (!response.ok)
+      throw new Error(`${response.status} ${response.statusText}`)
 
     const data = await response.json()
 
@@ -66,15 +67,4 @@ export default Gravity
 export interface Credentials {
   email: string
   password: string
-}
-
-interface AccessTokenRequest extends Credentials {
-  grant_type: string
-  client_id: string
-  client_secret: string
-}
-
-interface AccessTokenResponse {
-  access_token: string
-  expires_in: string
 }

--- a/src/utils/gravity.ts
+++ b/src/utils/gravity.ts
@@ -19,6 +19,19 @@ class Gravity {
     callback: `http://127.0.0.1:${Gravity.REDIRECT_PORT}`,
   }
 
+  static authUrl() {
+    const params = new URLSearchParams()
+
+    const clientId = process.env.CLIENT_ID as string
+
+    params.append("client_id", clientId)
+    params.append("redirect_uri", `http://127.0.0.1:${Gravity.REDIRECT_PORT}`)
+    params.append("response_type", "code")
+
+    const url = `${Gravity.urls.auth}?${params.toString()}`
+    return url
+  }
+
   static async getAccessToken(code: string) {
     const params = new URLSearchParams()
     params.append("code", code.toString())

--- a/src/utils/gravity.ts
+++ b/src/utils/gravity.ts
@@ -19,24 +19,24 @@ class Gravity {
     callback: `http://127.0.0.1:${Gravity.REDIRECT_PORT}`,
   }
 
-  async getAccessToken(credentials: Credentials) {
-    const gravityUrl = Gravity.urls.access_token
-    const body: AccessTokenRequest = {
-      client_id: process.env.CLIENT_ID!,
-      client_secret: process.env.CLIENT_SECRET!,
-      grant_type: "credentials",
-      ...credentials,
-    }
+  static async getAccessToken(code: string) {
+    const params = new URLSearchParams()
+    params.append("code", code.toString())
+    params.append("client_id", process.env.CLIENT_ID as string)
+    params.append("client_secret", process.env.CLIENT_SECRET as string)
+    params.append("grant_type", "authorization_code")
+    params.append("scope", "offline_access")
 
-    const response = await fetch(gravityUrl, {
-      method: "post",
-      body: JSON.stringify(body),
-      headers: { "Content-Type": "application/json" },
+    const response = await fetch(Gravity.urls.access_token, {
+      method: "POST",
+      body: params,
     })
 
-    const json = await response.json()
+    if (!response.ok) throw `${response.status} ${response.statusText}`
 
-    return json as AccessTokenResponse
+    const data = await response.json()
+
+    return data
   }
 
   async get(endpoint: string) {

--- a/src/utils/gravity.ts
+++ b/src/utils/gravity.ts
@@ -22,9 +22,7 @@ class Gravity {
   static authUrl() {
     const params = new URLSearchParams()
 
-    const clientId = process.env.CLIENT_ID as string
-
-    params.append("client_id", clientId)
+    params.append("client_id", Config.gravityId())
     params.append("redirect_uri", `http://127.0.0.1:${Gravity.REDIRECT_PORT}`)
     params.append("response_type", "code")
 
@@ -35,8 +33,8 @@ class Gravity {
   static async getAccessToken(code: string) {
     const params = new URLSearchParams()
     params.append("code", code.toString())
-    params.append("client_id", process.env.CLIENT_ID as string)
-    params.append("client_secret", process.env.CLIENT_SECRET as string)
+    params.append("client_id", Config.gravityId())
+    params.append("client_secret", Config.gravitySecret())
     params.append("grant_type", "authorization_code")
     params.append("scope", "offline_access")
 

--- a/src/utils/gravity.ts
+++ b/src/utils/gravity.ts
@@ -40,7 +40,7 @@ class Gravity {
   }
 
   async get(endpoint: string) {
-    const token: string = Config.readToken()
+    const token: string = Config.gravityToken()
 
     const gravityUrl: string = Gravity.url(`api/v1/${endpoint}`)
     const headers = { "X-Access-Token": token }

--- a/test/setup-mocha.ts
+++ b/test/setup-mocha.ts
@@ -2,6 +2,6 @@ import { Config } from "../src/config"
 
 before(() => {
   Config.path = () => "mock-path"
-  Config.readToken = () => "mock-token"
+  Config.gravityToken = () => "mock-token"
   Config.writeToken = () => null // noop
 })


### PR DESCRIPTION
This PR changes how we do configuration for artsy-cli - rather than using ENV vars it seeks to use a JSON file. At this point I'm storing the Gravity id/secret in there and then if you login the associated access token. If we like this direction then we could move more things like the creds for Slack/GitHub/OpsGenie. I had to draw a line somewhere or else I'd still be refactoring things! 😝 

The changes here are breaking. It would mean that existing installs with a plaintext file at `~/.config/artsy` would need to be updated like so:

```
$ rm ~/.config/artsy
$ mkdir ~/.config/artsy
$ aws s3 cp s3://artsy-citadel/dev/artsy-cli-config.json ~/.config/artsy/config.json
```

And then the person could login again. Maybe that means I should bump the version?