### PR TITLE
feat: FacilitateIncidentReview supports off week calculation

### DIFF
--- a/src/commands/scheduled/facilitate-incident-review.ts
+++ b/src/commands/scheduled/facilitate-incident-review.ts
@@ -3,7 +3,7 @@ import Command from "../../base"
 import { Opsgenie } from "../../utils/opsgenie"
 import { convertEmailsToSlackMentions } from "../../utils/slack"
 
-type Dates = {
+interface Dates {
   baseDate: string
   exceptions: string[]
 }
@@ -55,9 +55,7 @@ export default class FacilitateIncidentReview extends Command {
         try {
           dates = JSON.parse(process.env.DATES)
         } catch (error) {
-          this.error(
-            `DATES env var is not a valid JSON string. Use --help for more info.`
-          )
+          this.error(`${error}. Use --help for more info.`)
         }
 
         if (isOffWeek(dates)) {
@@ -157,5 +155,6 @@ function isOffWeek(dates: Dates) {
   if (!dates.exceptions.includes(today.split("T")[0]) && val < 1.5) {
     return true
   }
+
   return false
 }


### PR DESCRIPTION
This expands the `FacilitateIncidentReview` command to support control of execution via ENV var `Dates` (in JSON string format).

`DATES` ENV var will be used to set a starting point via `baseDate` field and the command will exit early on the weeks that are "_Off weeks_" for Incident Reviews. In addition, an `exceptions` field can be set which would allow for whitelisting "Off week" dates.

As this command is going to be executed via Joule (bot) github actions, the intent is to allow for (_some_) control of execution based on dates without having to make code changes. In cases when the Incident Review meeting is canceled due to a Hackathon or an additional meeting is added to catch up, modifying the ENV var in Joule project will allow for some control of this cron-based command.