### PR TITLE
chore: bump min runtime version to v14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  auto: artsy/auto@1.4.0
-  yarn: artsy/yarn@5.1.3
+  auto: artsy/auto@2.1.0
+  yarn: artsy/yarn@6.2.0
 
 workflows:
   default:

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "typescript": "^4.2"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.0.0"
   },
   "files": [
     "bin",


### PR DESCRIPTION
Noticed that `package.json` file specified min node v10. One problem with this is that the config uses [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) which was added in node v14.0.0. Shall we bump the version then?