### PR TITLE
feat: support staging login and gravity env

### DIFF
--- a/src/clients/gravity.ts
+++ b/src/clients/gravity.ts
@@ -1,63 +1,71 @@
-import fetch from "node-fetch"
-import { Config } from "../config"
+import fetch from "node-fetch";
+import { Config } from "../config";
 
 export class Gravity {
-  static BASE_URL = `https://api.artsy.net/`
-  static REDIRECT_PORT = 27879
+  static BASE_URL_PRODUCTION = `https://api.artsy.net/`;
+  static BASE_URL_STAGING = `https://stagingapi.artsy.net/`; 
 
-  static url(endpoint: string) {
-    return `${Gravity.BASE_URL}${endpoint}`
+  static REDIRECT_PORT = 27879;
+
+  static baseUrl(isStaging: boolean = false) {
+    return isStaging ? Gravity.BASE_URL_STAGING : Gravity.BASE_URL_PRODUCTION;
   }
 
-  static urls = {
-    current_user: Gravity.url("api/current_user"),
-    auth: Gravity.url("oauth2/authorize"),
-    access_token: Gravity.url("oauth2/access_token"),
-    access_tokens: Gravity.url("api/tokens/access_token"),
-    user_details: Gravity.url("api/current_user"),
-    // tslint:disable-next-line:no-http-string
-    callback: `http://127.0.0.1:${Gravity.REDIRECT_PORT}`,
+  static url(endpoint: string, isStaging: boolean = false) {
+    return `${Gravity.baseUrl(isStaging)}${endpoint}`;
   }
 
-  static authUrl() {
-    const params = new URLSearchParams()
-
-    params.append("client_id", Config.gravityId())
-    params.append("redirect_uri", Gravity.urls.callback)
-    params.append("response_type", "code")
-
-    const url = `${Gravity.urls.auth}?${params.toString()}`
-    return url
+  static urls(isStaging: boolean = false) {
+    return {
+      current_user: Gravity.url("api/current_user", isStaging),
+      auth: Gravity.url("oauth2/authorize", isStaging),
+      access_token: Gravity.url("oauth2/access_token", isStaging),
+      access_tokens: Gravity.url("api/tokens/access_token", isStaging),
+      user_details: Gravity.url("api/current_user", isStaging),
+      callback: `http://127.0.0.1:${Gravity.REDIRECT_PORT}`,
+    };
   }
 
-  static async getAccessToken(code: string) {
-    const params = new URLSearchParams()
-    params.append("code", code.toString())
-    params.append("client_id", Config.gravityId())
-    params.append("client_secret", Config.gravitySecret())
-    params.append("grant_type", "authorization_code")
-    params.append("scope", "offline_access")
+  static authUrl(isStaging: boolean = false) {
+    const urls = Gravity.urls(isStaging);
+    const params = new URLSearchParams();
 
-    const response = await fetch(Gravity.urls.access_token, {
+    params.append("client_id", Config.gravityId());
+    params.append("redirect_uri", urls.callback);
+    params.append("response_type", "code");
+
+    const url = `${urls.auth}?${params.toString()}`;
+    return url;
+  }
+
+  static async getAccessToken(code: string, isStaging: boolean = false) {
+    const urls = Gravity.urls(isStaging);
+    const params = new URLSearchParams();
+    params.append("code", code.toString());
+    params.append("client_id", Config.gravityId());
+    params.append("client_secret", Config.gravitySecret());
+    params.append("grant_type", "authorization_code");
+    params.append("scope", "offline_access");
+
+    const response = await fetch(urls.access_token, {
       method: "POST",
       body: params,
-    })
+    });
 
     if (!response.ok)
-      throw new Error(`${response.status} ${response.statusText}`)
+      throw new Error(`${response.status} ${response.statusText}`);
 
-    const data = await response.json()
-
-    return data
+    const data = await response.json();
+    return data;
   }
 
-  async get(endpoint: string) {
-    const token: string = Config.gravityToken()
+  async get(endpoint: string, isStaging: boolean = false) {
+    const token: string = Config.gravityToken(isStaging);
 
-    const gravityUrl: string = Gravity.url(`api/v1/${endpoint}`)
-    const headers = { "X-Access-Token": token }
-    const response = await fetch(gravityUrl, { headers })
+    const gravityUrl: string = Gravity.url(`api/v1/${endpoint}`, isStaging);
+    const headers = { "X-Access-Token": token };
+    const response = await fetch(gravityUrl, { headers });
 
-    return response
+    return response;
   }
 }

--- a/src/clients/gravity.ts
+++ b/src/clients/gravity.ts
@@ -1,21 +1,21 @@
-import fetch from "node-fetch";
-import { Config } from "../config";
+import fetch from "node-fetch"
+import { Config } from "../config"
 
 export class Gravity {
-  static BASE_URL_PRODUCTION = `https://api.artsy.net/`;
-  static BASE_URL_STAGING = `https://stagingapi.artsy.net/`; 
+  static BASE_URL_PRODUCTION = `https://api.artsy.net/`
+  static BASE_URL_STAGING = `https://stagingapi.artsy.net/`
 
   static REDIRECT_PORT = 27879;
 
-  static baseUrl(isStaging: boolean = false) {
-    return isStaging ? Gravity.BASE_URL_STAGING : Gravity.BASE_URL_PRODUCTION;
+  static baseUrl(isStaging = false) {
+    return isStaging ? Gravity.BASE_URL_STAGING : Gravity.BASE_URL_PRODUCTION
   }
 
-  static url(endpoint: string, isStaging: boolean = false) {
-    return `${Gravity.baseUrl(isStaging)}${endpoint}`;
+  static url(endpoint: string, isStaging = false) {
+    return `${Gravity.baseUrl(isStaging)}${endpoint}`
   }
 
-  static urls(isStaging: boolean = false) {
+  static urls(isStaging = false) {
     return {
       current_user: Gravity.url("api/current_user", isStaging),
       auth: Gravity.url("oauth2/authorize", isStaging),
@@ -23,49 +23,49 @@ export class Gravity {
       access_tokens: Gravity.url("api/tokens/access_token", isStaging),
       user_details: Gravity.url("api/current_user", isStaging),
       callback: `http://127.0.0.1:${Gravity.REDIRECT_PORT}`,
-    };
+    }
   }
 
-  static authUrl(isStaging: boolean = false) {
-    const urls = Gravity.urls(isStaging);
-    const params = new URLSearchParams();
+  static authUrl(isStaging = false) {
+    const urls = Gravity.urls(isStaging)
+    const params = new URLSearchParams()
 
-    params.append("client_id", Config.gravityId());
-    params.append("redirect_uri", urls.callback);
-    params.append("response_type", "code");
+    params.append("client_id", Config.gravityId())
+    params.append("redirect_uri", urls.callback)
+    params.append("response_type", "code")
 
-    const url = `${urls.auth}?${params.toString()}`;
-    return url;
+    const url = `${urls.auth}?${params.toString()}`
+    return url
   }
 
-  static async getAccessToken(code: string, isStaging: boolean = false) {
-    const urls = Gravity.urls(isStaging);
-    const params = new URLSearchParams();
-    params.append("code", code.toString());
-    params.append("client_id", Config.gravityId());
-    params.append("client_secret", Config.gravitySecret());
-    params.append("grant_type", "authorization_code");
-    params.append("scope", "offline_access");
+  static async getAccessToken(code: string, isStaging = false) {
+    const urls = Gravity.urls(isStaging)
+    const params = new URLSearchParams()
+    params.append("code", code.toString())
+    params.append("client_id", Config.gravityId())
+    params.append("client_secret", Config.gravitySecret())
+    params.append("grant_type", "authorization_code")
+    params.append("scope", "offline_access")
 
     const response = await fetch(urls.access_token, {
       method: "POST",
       body: params,
-    });
+    })
 
     if (!response.ok)
-      throw new Error(`${response.status} ${response.statusText}`);
+      throw new Error(`${response.status} ${response.statusText}`)
 
-    const data = await response.json();
-    return data;
+    const data = await response.json()
+    return data
   }
 
-  async get(endpoint: string, isStaging: boolean = false) {
-    const token: string = Config.gravityToken(isStaging);
+  async get(endpoint: string, isStaging = false) {
+    const token: string = Config.gravityToken(isStaging)
 
-    const gravityUrl: string = Gravity.url(`api/v1/${endpoint}`, isStaging);
-    const headers = { "X-Access-Token": token };
-    const response = await fetch(gravityUrl, { headers });
+    const gravityUrl: string = Gravity.url(`api/v1/${endpoint}`, isStaging)
+    const headers = { "X-Access-Token": token }
+    const response = await fetch(gravityUrl, { headers })
 
-    return response;
+    return response
   }
 }

--- a/src/clients/gravity.ts
+++ b/src/clients/gravity.ts
@@ -5,7 +5,7 @@ export class Gravity {
   static BASE_URL_PRODUCTION = `https://api.artsy.net/`
   static BASE_URL_STAGING = `https://stagingapi.artsy.net/`
 
-  static REDIRECT_PORT = 27879;
+  static REDIRECT_PORT = 27879
 
   static baseUrl(isStaging = false) {
     return isStaging ? Gravity.BASE_URL_STAGING : Gravity.BASE_URL_PRODUCTION
@@ -22,6 +22,7 @@ export class Gravity {
       access_token: Gravity.url("oauth2/access_token", isStaging),
       access_tokens: Gravity.url("api/tokens/access_token", isStaging),
       user_details: Gravity.url("api/current_user", isStaging),
+      // tslint:disable-next-line:no-http-string
       callback: `http://127.0.0.1:${Gravity.REDIRECT_PORT}`,
     }
   }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,9 +1,9 @@
+import { flags } from "@oclif/command"
 import cli from "cli-ux"
 import { parse } from "querystring"
 import Command from "../base"
 import { Gravity } from "../clients/gravity"
 import { Config } from "../config"
-import { flags } from "@oclif/command"
 
 export default class Login extends Command {
   static description =
@@ -37,14 +37,17 @@ export default class Login extends Command {
 
       if (query.code) {
         try {
-          const data = await Gravity.getAccessToken(query.code.toString(), isStaging)
+          const data = await Gravity.getAccessToken(
+            query.code.toString(),
+            isStaging
+          )
           if (isStaging) {
             Config.updateConfig({ stagingAccessToken: data.access_token })
-          }  else {
+          } else {
             Config.updateConfig({ accessToken: data.access_token })
           }
           cli.action.stop("logged in!")
-        } catch (error: any) {
+        } catch (error) {
           this.error(error)
         }
       }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -15,8 +15,8 @@ export default class Login extends Command {
   }
 
   async run() {
-    const { flags } = this.parse(Login);
-    const isStaging = flags.staging;
+    const { flags } = this.parse(Login)
+    const isStaging = flags.staging
 
     await cli.anykey("Ready! Press any key to initiate authorization flow")
 

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -12,7 +12,7 @@ export default class Logout extends Command {
   }
 
   async run() {
-    const { flags } = this.parse(Logout);
+    const { flags } = this.parse(Logout)
     const isStaging = flags.staging
 
     const token = Config.gravityToken()

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,4 +1,4 @@
-import { Command, flags } from "@oclif/command"
+import { Command } from "@oclif/command"
 import fetch from "node-fetch"
 import { Gravity } from "../clients/gravity"
 import { Config } from "../config"
@@ -37,10 +37,14 @@ export default class Logout extends Command {
     })
 
     if (!response.ok) {
-      this.error(`Failed to log out from ${isStaging ? 'staging' : 'production'} environment: ${response.status} ${response.statusText}`)
+      this.error(
+        `Failed to log out from ${
+          isStaging ? "staging" : "production"
+        } environment: ${response.status} ${response.statusText}`
+      )
     }
 
     const tokenKey = isStaging ? "stagingAccessToken" : "accessToken"
-    Config.updateConfig({ tokenKey : "" })
+    Config.updateConfig({ [tokenKey]: "" })
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,13 +44,13 @@ export const Config = {
   gravityToken: (isStaging = false) => {
     const json = Config.readConfig()
 
-    const stagingTokenKey = "GRAVITY_STAGING_ACCESS_TOKEN";
-    const productionTokenKey = "GRAVITY_ACCESS_TOKEN";
+    const stagingTokenKey = "GRAVITY_STAGING_ACCESS_TOKEN"
+    const productionTokenKey = "GRAVITY_ACCESS_TOKEN"
 
     if (isStaging) {
-      return json.stagingAccessToken || process.env[stagingTokenKey] || "";
+      return json.stagingAccessToken || process.env[stagingTokenKey] || ""
     } else {
-      return json.accessToken || process.env[productionTokenKey] || "";
+      return json.accessToken || process.env[productionTokenKey] || ""
     }
   },
   opsGenieApiKey: (): string => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,9 +41,17 @@ export const Config = {
       ""
     )
   },
-  gravityToken: (): string => {
+  gravityToken: (isStaging: boolean = false) => {
     const json = Config.readConfig()
-    return json.accessToken || process.env.GRAVITY_ACCESS_TOKEN || ""
+
+    const stagingTokenKey = "GRAVITY_STAGING_ACCESS_TOKEN";
+    const productionTokenKey = "GRAVITY_ACCESS_TOKEN";
+
+    if (isStaging) {
+      return json.stagingAccessToken || process.env[stagingTokenKey] || "";
+    } else {
+      return json.accessToken || process.env[productionTokenKey] || "";
+    }
   },
   opsGenieApiKey: (): string => {
     const json = Config.readConfig()

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,7 +41,7 @@ export const Config = {
       ""
     )
   },
-  gravityToken: (isStaging: boolean = false) => {
+  gravityToken: (isStaging = false) => {
     const json = Config.readConfig()
 
     const stagingTokenKey = "GRAVITY_STAGING_ACCESS_TOKEN";


### PR DESCRIPTION
Adds basic support for:
- logging into staging
- switching between staging and prod in Gravity client
- clearing out tokens from both environments

e.g:
`artsy login --staging`
will open the staging login flow and set a staging token in the config. 

Needed this for another project but seems generally useful in the meantime! Let me know any feedback

Based on this discussion from initial implementation: https://github.com/artsy/cli/pull/62/files#r580642852