### PR TITLE
feat: add Sapphire ceremony reminders to schedules

### DIFF
--- a/src/commands/scheduled/sapphire-next-on-call-retro.ts
+++ b/src/commands/scheduled/sapphire-next-on-call-retro.ts
@@ -1,0 +1,48 @@
+import Command from "../../base"
+
+import { Opsgenie } from "../../utils/opsgenie"
+import { convertEmailsToSlackMentions } from "../../utils/slack"
+
+export default class NextOnCall extends Command {
+  static urls: { [key: string]: string } = {
+    sapphireRetroInformation:
+      "https://www.notion.so/artsy/Retros-0b23b316be19470386ae0f550a57ab36",
+  }
+  static description = "Remind Sapphire members that are due to run retro."
+
+  static flags = {
+    ...Command.flags,
+  }
+
+  async run() {
+    const emails = await this.nextOnCallEmailsFromOpsGenie()
+    const mentions = await convertEmailsToSlackMentions(emails)
+
+    const payload = JSON.stringify({
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `${mentions.join(
+              ", "
+            )} you're scheduled to run Sapphire retro today! Check out the <${
+              NextOnCall.urls.sapphireRetroInformation
+            }|Retro info doc> to prepare.`,
+          },
+        },
+      ],
+    })
+
+    this.log(payload)
+  }
+
+  async nextOnCallEmailsFromOpsGenie() {
+    const opsgenie = new Opsgenie()
+    const onCalls = await opsgenie.scheduleNextOnCalls("Sapphire Retro Rotation")
+
+    return onCalls.data.exactNextOnCallRecipients.map((participant: any) => {
+      return participant.name
+    })
+  }
+}

--- a/src/commands/scheduled/sapphire-next-on-call-retro.ts
+++ b/src/commands/scheduled/sapphire-next-on-call-retro.ts
@@ -39,7 +39,9 @@ export default class NextOnCall extends Command {
 
   async nextOnCallEmailsFromOpsGenie() {
     const opsgenie = new Opsgenie()
-    const onCalls = await opsgenie.scheduleNextOnCalls("Sapphire Retro Rotation")
+    const onCalls = await opsgenie.scheduleNextOnCalls(
+      "Sapphire Retro Rotation"
+    )
 
     return onCalls.data.exactNextOnCallRecipients.map((participant: any) => {
       return participant.name

--- a/src/commands/scheduled/sapphire-next-on-call.ts
+++ b/src/commands/scheduled/sapphire-next-on-call.ts
@@ -1,0 +1,43 @@
+import Command from "../../base"
+
+import { Opsgenie } from "../../utils/opsgenie"
+import { convertEmailsToSlackMentions } from "../../utils/slack"
+
+export default class NextOnCall extends Command {
+
+  static description = "Remind Sapphire members that are due to run upcoming ceremonies."
+
+  static flags = {
+    ...Command.flags,
+  }
+
+  async run() {
+    const emails = await this.nextOnCallEmailsFromOpsGenie()
+    const mentions = await convertEmailsToSlackMentions(emails)
+
+    const payload = JSON.stringify({
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `${mentions.join(
+              ", "
+            )} you're scheduled to run the Sapphire ceremonies, excluding retro, for the upcoming week!`,
+          },
+        },
+      ],
+    })
+
+    this.log(payload)
+  }
+
+  async nextOnCallEmailsFromOpsGenie() {
+    const opsgenie = new Opsgenie()
+    const onCalls = await opsgenie.scheduleNextOnCalls("Sapphire Weekly Ceremonies Rotation Excluding Retro")
+
+    return onCalls.data.exactNextOnCallRecipients.map((participant: any) => {
+      return participant.name
+    })
+  }
+}

--- a/src/commands/scheduled/sapphire-next-on-call.ts
+++ b/src/commands/scheduled/sapphire-next-on-call.ts
@@ -4,8 +4,8 @@ import { Opsgenie } from "../../utils/opsgenie"
 import { convertEmailsToSlackMentions } from "../../utils/slack"
 
 export default class NextOnCall extends Command {
-
-  static description = "Remind Sapphire members that are due to run upcoming ceremonies."
+  static description =
+    "Remind Sapphire members that are due to run upcoming ceremonies."
 
   static flags = {
     ...Command.flags,
@@ -34,7 +34,9 @@ export default class NextOnCall extends Command {
 
   async nextOnCallEmailsFromOpsGenie() {
     const opsgenie = new Opsgenie()
-    const onCalls = await opsgenie.scheduleNextOnCalls("Sapphire Weekly Ceremonies Rotation Excluding Retro")
+    const onCalls = await opsgenie.scheduleNextOnCalls(
+      "Sapphire Weekly Ceremonies Rotation Excluding Retro"
+    )
 
     return onCalls.data.exactNextOnCallRecipients.map((participant: any) => {
       return participant.name

--- a/test/commands/scheduled/sapphire-next-on-call-retro.test.ts
+++ b/test/commands/scheduled/sapphire-next-on-call-retro.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@oclif/test"
+
+describe("scheduled:sapphire-next-on-call-retro", () => {
+  beforeEach(() => {
+    process.env.OPSGENIE_API_KEY = "test"
+  })
+  afterEach(() => {
+    delete process.env.OPSGENIE_API_KEY
+  })
+  test
+    .nock("https://api.opsgenie.com", (api) =>
+      api.get(/\/v2\/schedules\/.*\/next-on-calls.*/).reply(200, {
+        data: {
+          exactNextOnCallRecipients: [{ name: "justin@example.com" }],
+        },
+      })
+    )
+    .nock("https://slack.com/api", (api) =>
+      api
+        .post("/users.lookupByEmail", /email=justin%40example.com/)
+        .reply(200, {
+          ok: true,
+          user: {
+            id: "justin",
+          },
+        })
+    )
+    .stdout()
+    .command(["scheduled:sapphire-next-on-call-retro"])
+    .it(
+      "returns Slack-formatted upcoming on-call shift reminder message",
+      (ctx) => {
+        expect(ctx.stdout.trim()).to.eq(
+          JSON.stringify({
+            blocks: [
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: "<@justin> you're scheduled to run Sapphire retro today! Check out the <https://www.notion.so/artsy/Retros-0b23b316be19470386ae0f550a57ab36|Retro info doc> to prepare.",
+                },
+              },
+            ],
+          })
+        )
+      }
+    )
+})

--- a/test/commands/scheduled/sapphire-next-on-call.test.ts
+++ b/test/commands/scheduled/sapphire-next-on-call.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@oclif/test"
+
+describe("scheduled:sapphire-next-on-call", () => {
+  beforeEach(() => {
+    process.env.OPSGENIE_API_KEY = "test"
+  })
+  afterEach(() => {
+    delete process.env.OPSGENIE_API_KEY
+  })
+  test
+    .nock("https://api.opsgenie.com", (api) =>
+      api.get(/\/v2\/schedules\/.*\/next-on-calls.*/).reply(200, {
+        data: {
+          exactNextOnCallRecipients: [{ name: "justin@example.com" }],
+        },
+      })
+    )
+    .nock("https://slack.com/api", (api) =>
+      api
+        .post("/users.lookupByEmail", /email=justin%40example.com/)
+        .reply(200, {
+          ok: true,
+          user: {
+            id: "justin",
+          },
+        })
+    )
+    .stdout()
+    .command(["scheduled:sapphire-next-on-call"])
+    .it(
+      "returns Slack-formatted upcoming on-call shift reminder message",
+      (ctx) => {
+        expect(ctx.stdout.trim()).to.eq(
+          JSON.stringify({
+            blocks: [
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: "<@justin> you're scheduled to run the Sapphire ceremonies, excluding retro, for the upcoming week!",
+                },
+              },
+            ],
+          })
+        )
+      }
+    )
+})


### PR DESCRIPTION
Adding two reminders for Sapphire ceremony rotations by calling opsgenie and sending Slack messages. These will need to be scheduled in joules.