### PR TITLE
chore: update next on call incident handling link

### DIFF
--- a/src/commands/scheduled/next-on-call.ts
+++ b/src/commands/scheduled/next-on-call.ts
@@ -6,7 +6,7 @@ import { convertEmailsToSlackMentions } from "../../utils/slack"
 export default class NextOnCall extends Command {
   static urls: { [key: string]: string } = {
     incidentHandling:
-      "https://github.com/artsy/README/blob/main/playbooks/incident-handling.md#before-an-on-call-shift",
+      "https://www.notion.so/artsy/Incident-Handling-111cab0764a0808c993ec19b352cfab9?pvs=4#111cab0764a08052944df603067ca183",
   }
 
   static description = "Remind members with upcoming on-call shifts."

--- a/test/commands/scheduled/next-on-call.test.ts
+++ b/test/commands/scheduled/next-on-call.test.ts
@@ -48,7 +48,7 @@ describe("scheduled:next-on-call", () => {
                 text: {
                   type: "mrkdwn",
                   text:
-                    "<@justin>, <@steve> looks like you have on-call shifts coming up! Check out the <https://github.com/artsy/README/blob/main/playbooks/incident-handling.md#before-an-on-call-shift|Incident Handling doc> to prep. You've got this! :+1:",
+                    "<@justin>, <@steve> looks like you have on-call shifts coming up! Check out the <https://www.notion.so/artsy/Incident-Handling-111cab0764a0808c993ec19b352cfab9?pvs=4#111cab0764a08052944df603067ca183|Incident Handling doc> to prep. You've got this! :+1:",
                 },
               },
             ],


### PR DESCRIPTION
The incident-handling page was moved to notion. This updates NextOnCall to link to the correct location. Currently link returns 404.