### PR TITLE
docs: update README with npm-shrinkwrap instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ the proper version is released for your PR please chose one of the following lab
 - `Version: Minor`
 - `Version: Patch`
 - `Version: Trivial`
+
+### Updating pinned package versions
+
+The `npm-shrinkwrap.json` file locks all package versions (including transitive dependencies) to ensure consistent, reproducible builds across environments. This file is critical for security, as it prevents unexpected dependency updates that could introduce vulnerabilities. Without this file, the pinned package versions are not respected during `npm install`. To update the shrinkwrap file, run `npm shrinkwrap` to generate the updated `npm-shrinkwrap.json`.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@artsy/cli",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
         "@oclif/command": "^1",


### PR DESCRIPTION
We realised recently when the compromised NPM package versions were released that artsy cli installs via npm were not using the pinned package versions from `yarn.lock`. `npm-shrinkwrap.json` can be used to [lock the dependency versions](https://stackoverflow.com/questions/50743893/understanding-npm-shrinkwrap) in a project, so I added that on a previous commit and released. It seems `yarn.lock` is ignored. Here I am adding instructions about how to update this file.

I'm leaving this as a draft for now as after release we end up with two artsy/cli versions in `npm-shrinkwrap.json`, as the release process already [auto-bumps](https://github.com/artsy/cli/commit/885d6b6c0f7be71fea5257ceb06f22348b341006) the top level version but the the version within `packages` becomes stale. We may have to alter the release process... interested to hear other's thoughts.

`npm shrinkwrap` also corrupts the yarn.lock file and the tests no longer pass, so I have not committed the updates to yarn.lock. This isn't a very sustainable flow so will need some work.