### PR TITLE
feat: source security-bounty/sapphire rotations from Orbit

### DIFF
--- a/src/commands/scheduled/sapphire-on-call-retro.ts
+++ b/src/commands/scheduled/sapphire-on-call-retro.ts
@@ -1,6 +1,8 @@
 import Command from "../../base"
 
+import { Config } from "../../config"
 import { Opsgenie } from "../../utils/opsgenie"
+import { Orbit } from "../../utils/orbit"
 import { convertEmailsToSlackMentions } from "../../utils/slack"
 
 export default class SapphireOnCallRetro extends Command {
@@ -15,7 +17,7 @@ export default class SapphireOnCallRetro extends Command {
   }
 
   async run() {
-    const emails = await this.onCallEmailsFromOpsGenie()
+    const emails = await this.onCallEmails()
     const mentions = await convertEmailsToSlackMentions(emails)
 
     const payload = JSON.stringify({
@@ -35,6 +37,24 @@ export default class SapphireOnCallRetro extends Command {
     })
 
     this.log(payload)
+  }
+
+  // Prefers Orbit when a rotation id is configured (see ../../utils/orbit);
+  // otherwise (and if the Orbit lookup fails) falls back to the Opsgenie
+  // schedule, unchanged from before.
+  async onCallEmails() {
+    const orbitEmails = await this.onCallEmailsFromOrbit()
+    if (orbitEmails) return orbitEmails
+
+    return this.onCallEmailsFromOpsGenie()
+  }
+
+  async onCallEmailsFromOrbit() {
+    const rotationId = Config.orbitSapphireRetroRotationId()
+    if (!rotationId) return null
+
+    const orbit = new Orbit()
+    return orbit.onCallEmails(rotationId)
   }
 
   async onCallEmailsFromOpsGenie() {

--- a/src/commands/scheduled/sapphire-on-call.ts
+++ b/src/commands/scheduled/sapphire-on-call.ts
@@ -1,6 +1,8 @@
 import Command from "../../base"
 
+import { Config } from "../../config"
 import { Opsgenie } from "../../utils/opsgenie"
+import { Orbit } from "../../utils/orbit"
 import { convertEmailsToSlackMentions } from "../../utils/slack"
 
 export default class SapphireOnCall extends Command {
@@ -12,7 +14,7 @@ export default class SapphireOnCall extends Command {
   }
 
   async run() {
-    const emails = await this.onCallEmailsFromOpsGenie()
+    const emails = await this.onCallEmails()
     const mentions = await convertEmailsToSlackMentions(emails)
 
     const payload = JSON.stringify({
@@ -30,6 +32,24 @@ export default class SapphireOnCall extends Command {
     })
 
     this.log(payload)
+  }
+
+  // Prefers Orbit when a rotation id is configured (see ../../utils/orbit);
+  // otherwise (and if the Orbit lookup fails) falls back to the Opsgenie
+  // schedule, unchanged from before.
+  async onCallEmails() {
+    const orbitEmails = await this.onCallEmailsFromOrbit()
+    if (orbitEmails) return orbitEmails
+
+    return this.onCallEmailsFromOpsGenie()
+  }
+
+  async onCallEmailsFromOrbit() {
+    const rotationId = Config.orbitSapphireRotationId()
+    if (!rotationId) return null
+
+    const orbit = new Orbit()
+    return orbit.onCallEmails(rotationId)
   }
 
   async onCallEmailsFromOpsGenie() {

--- a/src/commands/scheduled/security-bounty-rotation.ts
+++ b/src/commands/scheduled/security-bounty-rotation.ts
@@ -1,6 +1,8 @@
 import Command from "../../base"
 
+import { Config } from "../../config"
 import { Opsgenie } from "../../utils/opsgenie"
+import { Orbit } from "../../utils/orbit"
 import { convertEmailsToSlackMentions } from "../../utils/slack"
 
 export default class SecurityBountyRotation extends Command {
@@ -16,7 +18,7 @@ export default class SecurityBountyRotation extends Command {
   }
 
   async run() {
-    const emails = await this.rotationEmailsFromOpsGenie()
+    const emails = await this.rotationEmails()
     const mentions = await convertEmailsToSlackMentions(emails)
 
     const payload = JSON.stringify({
@@ -36,6 +38,24 @@ export default class SecurityBountyRotation extends Command {
     })
 
     this.log(payload)
+  }
+
+  // Prefers Orbit when a rotation id is configured (see ../../utils/orbit);
+  // otherwise (and if the Orbit lookup fails) falls back to the Opsgenie
+  // schedule, unchanged from before.
+  async rotationEmails() {
+    const orbitEmails = await this.rotationEmailsFromOrbit()
+    if (orbitEmails) return orbitEmails
+
+    return this.rotationEmailsFromOpsGenie()
+  }
+
+  async rotationEmailsFromOrbit() {
+    const rotationId = Config.orbitSecurityBountyRotationId()
+    if (!rotationId) return null
+
+    const orbit = new Orbit()
+    return orbit.onCallEmails(rotationId)
   }
 
   async rotationEmailsFromOpsGenie() {

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,6 +57,38 @@ export const Config = {
     const json = Config.readConfig()
     return json.clients?.opsgenie?.apiKey || process.env.OPSGENIE_API_KEY || ""
   },
+  orbitUrl: (): string => {
+    const json = Config.readConfig()
+    return json.clients?.orbit?.url || process.env.ORBIT_URL || ""
+  },
+  orbitToken: (): string => {
+    const json = Config.readConfig()
+    return json.clients?.orbit?.token || process.env.ORBIT_TOKEN || ""
+  },
+  orbitSecurityBountyRotationId: (): string => {
+    const json = Config.readConfig()
+    return (
+      json.clients?.orbit?.securityBountyRotationId ||
+      process.env.ORBIT_SECURITY_BOUNTY_ROTATION_ID ||
+      ""
+    )
+  },
+  orbitSapphireRotationId: (): string => {
+    const json = Config.readConfig()
+    return (
+      json.clients?.orbit?.sapphireRotationId ||
+      process.env.ORBIT_SAPPHIRE_ROTATION_ID ||
+      ""
+    )
+  },
+  orbitSapphireRetroRotationId: (): string => {
+    const json = Config.readConfig()
+    return (
+      json.clients?.orbit?.sapphireRetroRotationId ||
+      process.env.ORBIT_SAPPHIRE_RETRO_ROTATION_ID ||
+      ""
+    )
+  },
   slackWebApiToken: (): string => {
     const json = Config.readConfig()
     return (

--- a/src/utils/orbit.ts
+++ b/src/utils/orbit.ts
@@ -1,0 +1,55 @@
+import fetch from "node-fetch"
+import { Config } from "../config"
+
+/**
+ * Client for Orbit (github.com/artsy/orbit), Artsy's on-call rotation
+ * scheduler, used as an opt-in alternative to an Opsgenie schedule.
+ *
+ * Orbit models a rotation as a single ordered on-call owner (with overrides
+ * and shift-swaps layered on top), so `onCallEmails` always resolves to at
+ * most one email — unlike Opsgenie's `onCallParticipants`, which can list
+ * several. Callers already treat that as a list of Slack mentions, so a
+ * single-element array is a drop-in replacement.
+ */
+export class Orbit {
+  url: string
+  token: string
+
+  constructor() {
+    this.url = Config.orbitUrl()
+    this.token = Config.orbitToken()
+  }
+
+  get isConfigured(): boolean {
+    return Boolean(this.url && this.token)
+  }
+
+  /**
+   * The email of whoever is currently on call for `rotationId`, or `null`
+   * when Orbit isn't configured, the rotation has no one on call right now,
+   * or the request fails — callers should fall back to Opsgenie in all of
+   * those cases.
+   */
+  async onCallEmails(rotationId: string): Promise<string[] | null> {
+    if (!this.isConfigured) return null
+
+    try {
+      const res = await fetch(
+        `${this.url}/api/rotations/${rotationId}/on-call`,
+        {
+          headers: { Authorization: `Bearer ${this.token}` },
+        }
+      )
+      if (!res.ok) {
+        throw new Error(`Orbit request failed (${res.status})`)
+      }
+
+      const body = await res.json()
+      const email = body?.current?.engineer?.email
+      return email ? [email] : []
+    } catch (error) {
+      console.error("Orbit lookup failed; falling back to Opsgenie.", error)
+      return null
+    }
+  }
+}

--- a/test/commands/scheduled/sapphire-on-call-retro.test.ts
+++ b/test/commands/scheduled/sapphire-on-call-retro.test.ts
@@ -1,4 +1,18 @@
 import { expect, test } from "@oclif/test"
+import { Config } from "../../../src/config"
+
+const expectedPayload = JSON.stringify({
+  blocks: [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text:
+          "<@justin> you're scheduled to run Sapphire retro today! Check out the <https://www.notion.so/artsy/Retros-0b23b316be19470386ae0f550a57ab36|Retro info doc> to prepare.",
+      },
+    },
+  ],
+})
 
 describe("scheduled:sapphire-on-call-retro", () => {
   beforeEach(() => {
@@ -30,20 +44,54 @@ describe("scheduled:sapphire-on-call-retro", () => {
     .it(
       "returns Slack-formatted upcoming on-call shift reminder message",
       ctx => {
-        expect(ctx.stdout.trim()).to.eq(
-          JSON.stringify({
-            blocks: [
-              {
-                type: "section",
-                text: {
-                  type: "mrkdwn",
-                  text:
-                    "<@justin> you're scheduled to run Sapphire retro today! Check out the <https://www.notion.so/artsy/Retros-0b23b316be19470386ae0f550a57ab36|Retro info doc> to prepare.",
-                },
-              },
-            ],
-          })
-        )
+        expect(ctx.stdout.trim()).to.eq(expectedPayload)
       }
     )
+
+  describe("when an Orbit rotation is configured", () => {
+    const originalOrbitUrl = Config.orbitUrl
+    const originalOrbitToken = Config.orbitToken
+    const originalRotationId = Config.orbitSapphireRetroRotationId
+
+    beforeEach(() => {
+      Config.orbitUrl = () => "https://orbit.artsy.net"
+      Config.orbitToken = () => "test-orbit-token"
+      Config.orbitSapphireRetroRotationId = () => "rotation-456"
+    })
+    afterEach(() => {
+      Config.orbitUrl = originalOrbitUrl
+      Config.orbitToken = originalOrbitToken
+      Config.orbitSapphireRetroRotationId = originalRotationId
+    })
+
+    test
+      .nock("https://orbit.artsy.net", api =>
+        api.get("/api/rotations/rotation-456/on-call").reply(200, {
+          current: {
+            engineer: { id: "e1", email: "justin@example.com" },
+            periodStart: "2026-01-01T00:00:00.000Z",
+            periodEnd: "2026-01-08T00:00:00.000Z",
+          },
+          next: null,
+        })
+      )
+      .nock("https://slack.com/api", api =>
+        api
+          .post("/users.lookupByEmail", /email=justin%40example.com/)
+          .reply(200, {
+            ok: true,
+            user: {
+              id: "justin",
+            },
+          })
+      )
+      .stdout()
+      .command(["scheduled:sapphire-on-call-retro"])
+      .it(
+        "resolves the on-call captain from Orbit instead of Opsgenie",
+        ctx => {
+          expect(ctx.stdout.trim()).to.eq(expectedPayload)
+        }
+      )
+  })
 })

--- a/test/commands/scheduled/sapphire-on-call.test.ts
+++ b/test/commands/scheduled/sapphire-on-call.test.ts
@@ -1,4 +1,18 @@
 import { expect, test } from "@oclif/test"
+import { Config } from "../../../src/config"
+
+const expectedPayload = JSON.stringify({
+  blocks: [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text:
+          "<@justin> you're scheduled to run the Sapphire ceremonies, excluding retro, for the upcoming week!",
+      },
+    },
+  ],
+})
 
 describe("scheduled:sapphire-on-call", () => {
   beforeEach(() => {
@@ -30,20 +44,54 @@ describe("scheduled:sapphire-on-call", () => {
     .it(
       "returns Slack-formatted upcoming on-call shift reminder message",
       ctx => {
-        expect(ctx.stdout.trim()).to.eq(
-          JSON.stringify({
-            blocks: [
-              {
-                type: "section",
-                text: {
-                  type: "mrkdwn",
-                  text:
-                    "<@justin> you're scheduled to run the Sapphire ceremonies, excluding retro, for the upcoming week!",
-                },
-              },
-            ],
-          })
-        )
+        expect(ctx.stdout.trim()).to.eq(expectedPayload)
       }
     )
+
+  describe("when an Orbit rotation is configured", () => {
+    const originalOrbitUrl = Config.orbitUrl
+    const originalOrbitToken = Config.orbitToken
+    const originalRotationId = Config.orbitSapphireRotationId
+
+    beforeEach(() => {
+      Config.orbitUrl = () => "https://orbit.artsy.net"
+      Config.orbitToken = () => "test-orbit-token"
+      Config.orbitSapphireRotationId = () => "rotation-123"
+    })
+    afterEach(() => {
+      Config.orbitUrl = originalOrbitUrl
+      Config.orbitToken = originalOrbitToken
+      Config.orbitSapphireRotationId = originalRotationId
+    })
+
+    test
+      .nock("https://orbit.artsy.net", api =>
+        api.get("/api/rotations/rotation-123/on-call").reply(200, {
+          current: {
+            engineer: { id: "e1", email: "justin@example.com" },
+            periodStart: "2026-01-01T00:00:00.000Z",
+            periodEnd: "2026-01-08T00:00:00.000Z",
+          },
+          next: null,
+        })
+      )
+      .nock("https://slack.com/api", api =>
+        api
+          .post("/users.lookupByEmail", /email=justin%40example.com/)
+          .reply(200, {
+            ok: true,
+            user: {
+              id: "justin",
+            },
+          })
+      )
+      .stdout()
+      .command(["scheduled:sapphire-on-call"])
+      .it(
+        "resolves the on-call captain from Orbit instead of Opsgenie",
+        ctx => {
+          expect(ctx.stdout.trim()).to.eq(expectedPayload)
+        }
+      )
+  })
 })

--- a/test/commands/scheduled/security-bounty-rotation.test.ts
+++ b/test/commands/scheduled/security-bounty-rotation.test.ts
@@ -1,4 +1,18 @@
 import { expect, test } from "@oclif/test"
+import { Config } from "../../../src/config"
+
+const expectedPayload = JSON.stringify({
+  blocks: [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text:
+          "<@justin> you're scheduled to respond to bounty submissions in the upcoming week! Check out <https://www.notion.so/artsy/Security-Bounty-Program-Playbook-0071e3292a194f23b6a8ae593a08d3f3|the playbook> to prepare.",
+      },
+    },
+  ],
+})
 
 describe("scheduled:security-bounty-rotation", () => {
   beforeEach(() => {
@@ -30,20 +44,51 @@ describe("scheduled:security-bounty-rotation", () => {
     .it(
       "returns Slack-formatted upcoming security bounty shift reminder message",
       ctx => {
-        expect(ctx.stdout.trim()).to.eq(
-          JSON.stringify({
-            blocks: [
-              {
-                type: "section",
-                text: {
-                  type: "mrkdwn",
-                  text:
-                    "<@justin> you're scheduled to respond to bounty submissions in the upcoming week! Check out <https://www.notion.so/artsy/Security-Bounty-Program-Playbook-0071e3292a194f23b6a8ae593a08d3f3|the playbook> to prepare.",
-                },
-              },
-            ],
-          })
-        )
+        expect(ctx.stdout.trim()).to.eq(expectedPayload)
       }
     )
+
+  describe("when an Orbit rotation is configured", () => {
+    const originalOrbitUrl = Config.orbitUrl
+    const originalOrbitToken = Config.orbitToken
+    const originalRotationId = Config.orbitSecurityBountyRotationId
+
+    beforeEach(() => {
+      Config.orbitUrl = () => "https://orbit.artsy.net"
+      Config.orbitToken = () => "test-orbit-token"
+      Config.orbitSecurityBountyRotationId = () => "rotation-789"
+    })
+    afterEach(() => {
+      Config.orbitUrl = originalOrbitUrl
+      Config.orbitToken = originalOrbitToken
+      Config.orbitSecurityBountyRotationId = originalRotationId
+    })
+
+    test
+      .nock("https://orbit.artsy.net", api =>
+        api.get("/api/rotations/rotation-789/on-call").reply(200, {
+          current: {
+            engineer: { id: "e1", email: "justin@example.com" },
+            periodStart: "2026-01-01T00:00:00.000Z",
+            periodEnd: "2026-01-08T00:00:00.000Z",
+          },
+          next: null,
+        })
+      )
+      .nock("https://slack.com/api", api =>
+        api
+          .post("/users.lookupByEmail", /email=justin%40example.com/)
+          .reply(200, {
+            ok: true,
+            user: {
+              id: "justin",
+            },
+          })
+      )
+      .stdout()
+      .command(["scheduled:security-bounty-rotation"])
+      .it("resolves the responder from Orbit instead of Opsgenie", ctx => {
+        expect(ctx.stdout.trim()).to.eq(expectedPayload)
+      })
+  })
 })


### PR DESCRIPTION
**Draft — for inspiration, not to merge.** Mirrors the [release-lookout integration](https://github.com/artsy/release-lookout/pull/40): lets [Orbit](https://github.com/artsy/orbit) (Artsy's on-call rotation scheduler) drive who's on call for these three scheduled reminders, instead of an Opsgenie schedule.

## What this does
- **`src/utils/orbit.ts`** — a small client: `GET /api/rotations/[id]/on-call` with a Bearer service token, returning the current on-call engineer's email. Returns `null` (not an error) when Orbit isn't configured or the request fails, so callers fall back safely — Orbit models a rotation as a single ordered owner, so this is always at most one email.
- **`src/config.ts`** — `ORBIT_URL` / `ORBIT_TOKEN` (shared), plus one rotation-id getter per command (`ORBIT_SECURITY_BOUNTY_ROTATION_ID`, `ORBIT_SAPPHIRE_ROTATION_ID`, `ORBIT_SAPPHIRE_RETRO_ROTATION_ID`) — same `config.json` override → env var fallback convention as the existing `opsGenieApiKey`/`slackWebApiToken` getters.
- **`security-bounty-rotation.ts`, `sapphire-on-call.ts`, `sapphire-on-call-retro.ts`** — each tries Orbit first (only when its rotation id is configured) and falls back to the existing Opsgenie schedule otherwise.

**Opt-in only:** with no `ORBIT_*` env vars set (today's default), behavior is completely unchanged.

## Why
These are exactly the kind of rotation Orbit already models — an ordered on-call owner with overrides/shift-swaps layered on top — so moving them off Opsgenie schedules means coverage changes (someone out sick, a swap) show up automatically instead of needing an Opsgenie schedule edit.

## Where this runs
These commands are invoked by scheduled GitHub Actions workflows in [artsy/joule](https://github.com/artsy/joule) (`sapphire-on-call.yml`, `sapphire-on-call-retro.yml`, `security-bounty-rotation.yml`), which pass `OPSGENIE_API_KEY`/`SLACK_WEB_API_TOKEN` as env vars today. To actually turn this on for a given rotation, joule's corresponding workflow would need `ORBIT_URL`, `ORBIT_TOKEN`, and that command's rotation-id secret added to its `Run CLI` step — not done here, since that's a separate repo/PR.

## Test plan
- `tsc --noEmit`, `yarn lint`, `yarn test` all pass (37 passing; 2 pre-existing `scheduled:rfcs` failures are unrelated to this change — confirmed present on `main` before this diff too).
- Added an Orbit-path test per command (nocking `https://orbit.artsy.net`) alongside the existing Opsgenie test, so both paths are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKQn1QibQsnUP3CPqPBJ5z

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKQn1QibQsnUP3CPqPBJ5z)_